### PR TITLE
Add Prometheus and Grafana observability stack

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report incorrect behavior in order-service, notification-stub, or infrastructure setup.
-title: "[Bug]: "
+title: "Transactional Outbox Pattern - [Bug]: "
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an enhancement to the transactional outbox demo or its tooling.
-title: "[Feature]: "
+title: "Transactional Outbox Pattern - [Feature]: "
 labels:
   - enhancement
 body:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thank you for your interest in contributing to **spring-transactional-outbox-kaf
 
 * Java 21
 * Maven 3.9+
-* Docker (for PostgreSQL, Kafka, and integration tests)
+* Docker (for PostgreSQL, Kafka, Prometheus, Grafana, and integration tests)
 
 ### Build and test
 
@@ -35,6 +35,8 @@ mvn clean package -DskipTests
 mvn -pl order-service spring-boot:run -Dspring-boot.run.profiles=dev
 mvn -pl notification-stub spring-boot:run -Dspring-boot.run.profiles=dev
 ```
+
+Metrics: Prometheus http://localhost:9090, Grafana http://localhost:3000 — see [README Observability](README.md#observability).
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,51 @@ Key settings in `order-service/src/main/resources/application.yml`:
 
 Kafka messages use **partition key = `customerId`**.
 
+## Observability
+
+The local stack includes **Prometheus** and **Grafana** (via Docker Compose). Applications run on the host and expose metrics through Spring Boot Actuator.
+
+### 1. Start infrastructure (including monitoring)
+
+```bash
+docker compose up -d
+```
+
+| Service | URL | Notes |
+|---------|-----|-------|
+| Prometheus | http://localhost:9090 | scrapes `host.docker.internal:8080` and `:8081` |
+| Grafana | http://localhost:3000 | login `admin` / `admin` (dev only) |
+
+### 2. Run services and generate traffic
+
+```bash
+mvn -pl order-service spring-boot:run -Dspring-boot.run.profiles=dev
+mvn -pl notification-stub spring-boot:run -Dspring-boot.run.profiles=dev
+```
+
+Verify metrics endpoints:
+
+```bash
+curl -s http://localhost:8080/actuator/prometheus | head
+curl -s http://localhost:8081/actuator/prometheus | head
+```
+
+Create an order (see API example above), then open Grafana — dashboard **Transactional Outbox** is provisioned automatically.
+
+Prometheus targets: http://localhost:9090/targets (`order-service`, `notification-stub` should be **UP** while apps are running).
+
+### Custom outbox metrics (`order-service`)
+
+| Metric | Description |
+|--------|-------------|
+| `outbox.queue.size` | In-memory queue size |
+| `outbox.queue.pressure` | Queue fill ratio (0–1) |
+| `outbox.publish.latency` | Kafka publish duration |
+| `outbox.publish.failures` | Failed publish attempts |
+| `outbox.retry.count` | Publisher retries |
+| `outbox.recovery.count` | Events re-enqueued by recovery worker |
+| `outbox.rate_limit.rejects` | HTTP 429 responses |
+
 ## Failure scenarios (local)
 
 | Scenario | Expected behavior |

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ docker compose up -d
 
 | Service | URL | Notes |
 |---------|-----|-------|
-| Prometheus | http://localhost:9090 | scrapes `host.docker.internal:8080` and `:8081` |
+| Prometheus | http://localhost:9090 | scrapes apps on host + `postgres-exporter` |
 | Grafana | http://localhost:3000 | login `admin` / `admin` (dev only) |
+| postgres-exporter | http://localhost:9187/metrics | standard PostgreSQL metrics |
 
 ### 2. Run services and generate traffic
 
@@ -101,9 +102,9 @@ curl -s http://localhost:8080/actuator/prometheus | head
 curl -s http://localhost:8081/actuator/prometheus | head
 ```
 
-Create an order (see API example above), then open Grafana — dashboard **Transactional Outbox** is provisioned automatically.
+Create an order (see API example above), then open Grafana — dashboards **Transactional Outbox**, **Notification Stub**, and **PostgreSQL** are provisioned automatically.
 
-Prometheus targets: http://localhost:9090/targets (`order-service`, `notification-stub` should be **UP** while apps are running).
+Prometheus targets: http://localhost:9090/targets (`order-service`, `notification-stub`, `postgres` should be **UP** while the stack is running).
 
 ### Custom outbox metrics (`order-service`)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,16 @@ services:
       timeout: 5s
       retries: 10
 
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.16.0
+    environment:
+      DATA_SOURCE_NAME: "postgresql://outbox:outbox@postgres:5432/outbox?sslmode=disable"
+    ports:
+      - "9187:9187"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   kafka:
     image: apache/kafka:3.8.1
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,3 +30,28 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    ports:
+      - "9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+
+  grafana:
+    image: grafana/grafana:11.6.0
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -7,5 +7,6 @@ providers:
     type: file
     disableDeletion: false
     editable: true
+    updateIntervalSeconds: 30
     options:
       path: /etc/grafana/provisioning/dashboards

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: transactional-outbox
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/monitoring/grafana/provisioning/dashboards/notification-stub-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/notification-stub-dashboard.json
@@ -8,15 +8,9 @@
   "id": null,
   "links": [
     {
-      "title": "Notification Stub",
+      "title": "Transactional Outbox",
       "type": "link",
-      "url": "/d/notification-stub/notification-stub",
-      "icon": "external link"
-    },
-    {
-      "title": "PostgreSQL",
-      "type": "link",
-      "url": "/d/postgresql/postgresql",
+      "url": "/d/transactional-outbox/transactional-outbox",
       "icon": "external link"
     }
   ],
@@ -31,39 +25,50 @@
           "color": {
             "mode": "thresholds"
           },
-          "min": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
               },
               {
-                "color": "yellow",
-                "value": 100
-              },
-              {
-                "color": "red",
-                "value": 1000
+                "color": "green",
+                "value": 1
               }
             ]
-          },
-          "unit": "short"
+          }
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 4,
         "x": 0,
         "y": 0
       },
       "id": 1,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -80,12 +85,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "outbox_queue_size{job=\"order-service\"}",
-          "legendFormat": "queue size",
+          "expr": "up{job=\"notification-stub\"}",
+          "legendFormat": "scrape",
           "refId": "A"
         }
       ],
-      "title": "Outbox Queue Size (current)",
+      "title": "Prometheus Target",
       "type": "stat"
     },
     {
@@ -96,35 +101,16 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.8
-              },
-              {
-                "color": "red",
-                "value": 0.95
-              }
-            ]
-          },
-          "unit": "percentunit"
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 6,
+        "w": 10,
+        "x": 4,
         "y": 0
       },
       "id": 2,
@@ -148,12 +134,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "outbox_queue_pressure{job=\"order-service\"}",
-          "legendFormat": "queue pressure",
+          "expr": "notification_events_received_total{job=\"notification-stub\"}",
+          "legendFormat": "events total",
           "refId": "A"
         }
       ],
-      "title": "Outbox Queue Pressure (current)",
+      "title": "Events Received (total)",
       "type": "stat"
     },
     {
@@ -166,26 +152,30 @@
           "color": {
             "mode": "palette-classic"
           },
-          "min": 0,
           "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 4
+        "h": 4,
+        "w": 10,
+        "x": 14,
+        "y": 0
       },
-      "id": 7,
+      "id": 3,
       "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "single"
-        }
+        "textMode": "auto"
       },
       "targets": [
         {
@@ -193,13 +183,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "outbox_queue_size{job=\"order-service\"}",
-          "legendFormat": "queue size",
+          "expr": "notification_batches_received_total{job=\"notification-stub\"}",
+          "legendFormat": "batches total",
           "refId": "A"
         }
       ],
-      "title": "Outbox Queue Size (history)",
-      "type": "timeseries"
+      "title": "Batches Received (total)",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -211,19 +201,17 @@
           "color": {
             "mode": "palette-classic"
           },
-          "max": 1,
-          "min": 0,
-          "unit": "percentunit"
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
+        "x": 0,
         "y": 4
       },
-      "id": 8,
+      "id": 4,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -239,12 +227,21 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "outbox_queue_pressure{job=\"order-service\"}",
-          "legendFormat": "queue pressure",
+          "expr": "rate(notification_events_received_total{job=\"notification-stub\"}[5m])",
+          "legendFormat": "events/s",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(notification_batches_received_total{job=\"notification-stub\"}[5m])",
+          "legendFormat": "batches/s",
+          "refId": "B"
         }
       ],
-      "title": "Outbox Queue Pressure (history)",
+      "title": "Consumption Throughput",
       "type": "timeseries"
     },
     {
@@ -264,54 +261,10 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 12
-      },
-      "id": 3,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(outbox_publish_latency_seconds_sum{job=\"order-service\"}[5m]) / rate(outbox_publish_latency_seconds_count{job=\"order-service\"}[5m])",
-          "legendFormat": "avg latency",
-          "refId": "A"
-        }
-      ],
-      "title": "Publish Latency p95",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 12,
-        "y": 12
+        "y": 4
       },
-      "id": 4,
+      "id": 5,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -327,8 +280,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(outbox_publish_failures_total{job=\"order-service\"}[5m])",
-          "legendFormat": "failures/s",
+          "expr": "rate(notification_batch_processing_seconds_sum{job=\"notification-stub\"}[5m]) / rate(notification_batch_processing_seconds_count{job=\"notification-stub\"}[5m])",
+          "legendFormat": "avg batch processing",
           "refId": "A"
         },
         {
@@ -336,30 +289,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(outbox_retry_count_total{job=\"order-service\"}[5m])",
-          "legendFormat": "retries/s",
+          "expr": "sum(rate(spring_kafka_listener_seconds_sum{job=\"notification-stub\"}[5m])) / sum(rate(spring_kafka_listener_seconds_count{job=\"notification-stub\"}[5m]))",
+          "legendFormat": "avg kafka listener",
           "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(outbox_recovery_count_total{job=\"order-service\"}[5m])",
-          "legendFormat": "recovery/s",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(outbox_rate_limit_rejects_total{job=\"order-service\"}[5m])",
-          "legendFormat": "rate-limit rejects/s",
-          "refId": "D"
         }
       ],
-      "title": "Failures, Retries, Recovery, Rate Limits",
+      "title": "Processing Latency (avg)",
       "type": "timeseries"
     },
     {
@@ -380,51 +315,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 20
-      },
-      "id": 5,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "jvm_memory_used_bytes{job=\"order-service\", area=\"heap\"}",
-          "legendFormat": "{{id}}",
-          "refId": "A"
-        }
-      ],
-      "title": "JVM Heap Used",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 20
+        "y": 12
       },
       "id": 6,
       "options": {
@@ -442,19 +333,63 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(http_server_requests_seconds_count{job=\"order-service\"}[5m])) by (uri, status)",
-          "legendFormat": "{{uri}} {{status}}",
+          "expr": "jvm_memory_used_bytes{job=\"notification-stub\", area=\"heap\"}",
+          "legendFormat": "{{id}}",
           "refId": "A"
         }
       ],
-      "title": "HTTP Request Rate",
+      "title": "JVM Heap Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(spring_kafka_listener_seconds_count{job=\"notification-stub\"}[5m])) by (name, result)",
+          "legendFormat": "{{name}} {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Kafka Listener Invocations / sec",
       "type": "timeseries"
     }
   ],
   "refresh": "10s",
   "schemaVersion": 39,
   "tags": [
-    "outbox",
+    "notification",
     "kafka",
     "spring-boot"
   ],
@@ -467,7 +402,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Transactional Outbox",
-  "uid": "transactional-outbox",
-  "version": 3
+  "title": "Notification Stub",
+  "uid": "notification-stub",
+  "version": 2
 }

--- a/monitoring/grafana/provisioning/dashboards/outbox-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/outbox-dashboard.json
@@ -1,0 +1,324 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "outbox_queue_size{application=\"order-service\"}",
+          "legendFormat": "queue size",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbox Queue Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "outbox_queue_pressure{application=\"order-service\"}",
+          "legendFormat": "queue pressure",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbox Queue Pressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(outbox_publish_latency_seconds_bucket{application=\"order-service\"}[5m])) by (le))",
+          "legendFormat": "p95 latency",
+          "refId": "A"
+        }
+      ],
+      "title": "Publish Latency p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(outbox_publish_failures_total{application=\"order-service\"}[5m])",
+          "legendFormat": "failures/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(outbox_retry_count_total{application=\"order-service\"}[5m])",
+          "legendFormat": "retries/s",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(outbox_recovery_count_total{application=\"order-service\"}[5m])",
+          "legendFormat": "recovery/s",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(outbox_rate_limit_rejects_total{application=\"order-service\"}[5m])",
+          "legendFormat": "rate-limit rejects/s",
+          "refId": "D"
+        }
+      ],
+      "title": "Failures, Retries, Recovery, Rate Limits",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "jvm_memory_used_bytes{application=\"order-service\", area=\"heap\"}",
+          "legendFormat": "{{id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "JVM Heap Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"order-service\"}[5m])) by (uri, status)",
+          "legendFormat": "{{uri}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "outbox",
+    "kafka",
+    "spring-boot"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Transactional Outbox",
+  "uid": "transactional-outbox",
+  "version": 1
+}

--- a/monitoring/grafana/provisioning/dashboards/postgres-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/postgres-dashboard.json
@@ -6,20 +6,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [
-    {
-      "title": "Notification Stub",
-      "type": "link",
-      "url": "/d/notification-stub/notification-stub",
-      "icon": "external link"
-    },
-    {
-      "title": "PostgreSQL",
-      "type": "link",
-      "url": "/d/postgresql/postgresql",
-      "icon": "external link"
-    }
-  ],
+  "links": [],
   "panels": [
     {
       "datasource": {
@@ -31,21 +18,33 @@
           "color": {
             "mode": "thresholds"
           },
-          "min": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
               },
               {
-                "color": "yellow",
-                "value": 100
-              },
-              {
-                "color": "red",
-                "value": 1000
+                "color": "green",
+                "value": 1
               }
             ]
           },
@@ -55,15 +54,15 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 4,
         "x": 0,
         "y": 0
       },
       "id": 1,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -80,80 +79,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "outbox_queue_size{job=\"order-service\"}",
-          "legendFormat": "queue size",
+          "expr": "pg_up",
+          "legendFormat": "postgres",
           "refId": "A"
         }
       ],
-      "title": "Outbox Queue Size (current)",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.8
-              },
-              {
-                "color": "red",
-                "value": 0.95
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "outbox_queue_pressure{job=\"order-service\"}",
-          "legendFormat": "queue pressure",
-          "refId": "A"
-        }
-      ],
-      "title": "Outbox Queue Pressure (current)",
+      "title": "PostgreSQL Up",
       "type": "stat"
     },
     {
@@ -166,18 +97,17 @@
           "color": {
             "mode": "palette-classic"
           },
-          "min": 0,
           "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 4
+        "w": 10,
+        "x": 4,
+        "y": 0
       },
-      "id": 7,
+      "id": 2,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -193,12 +123,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "outbox_queue_size{job=\"order-service\"}",
-          "legendFormat": "queue size",
+          "expr": "sum(pg_stat_database_numbackends) by (datname)",
+          "legendFormat": "{{datname}}",
           "refId": "A"
         }
       ],
-      "title": "Outbox Queue Size (history)",
+      "title": "Active Connections",
       "type": "timeseries"
     },
     {
@@ -211,61 +141,15 @@
           "color": {
             "mode": "palette-classic"
           },
-          "max": 1,
-          "min": 0,
-          "unit": "percentunit"
+          "unit": "bytes"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 4
-      },
-      "id": 8,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "outbox_queue_pressure{job=\"order-service\"}",
-          "legendFormat": "queue pressure",
-          "refId": "A"
-        }
-      ],
-      "title": "Outbox Queue Pressure (history)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 12
+        "w": 10,
+        "x": 14,
+        "y": 0
       },
       "id": 3,
       "options": {
@@ -283,12 +167,65 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(outbox_publish_latency_seconds_sum{job=\"order-service\"}[5m]) / rate(outbox_publish_latency_seconds_count{job=\"order-service\"}[5m])",
-          "legendFormat": "avg latency",
+          "expr": "pg_database_size_bytes{datname=\"outbox\"}",
+          "legendFormat": "{{datname}}",
           "refId": "A"
         }
       ],
-      "title": "Publish Latency p95",
+      "title": "Database Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(pg_stat_database_xact_commit{datname=\"outbox\"}[5m])",
+          "legendFormat": "commits",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(pg_stat_database_xact_rollback{datname=\"outbox\"}[5m])",
+          "legendFormat": "rollbacks",
+          "refId": "B"
+        }
+      ],
+      "title": "Transactions / sec",
       "type": "timeseries"
     },
     {
@@ -309,78 +246,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 12
-      },
-      "id": 4,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(outbox_publish_failures_total{job=\"order-service\"}[5m])",
-          "legendFormat": "failures/s",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(outbox_retry_count_total{job=\"order-service\"}[5m])",
-          "legendFormat": "retries/s",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(outbox_recovery_count_total{job=\"order-service\"}[5m])",
-          "legendFormat": "recovery/s",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "rate(outbox_rate_limit_rejects_total{job=\"order-service\"}[5m])",
-          "legendFormat": "rate-limit rejects/s",
-          "refId": "D"
-        }
-      ],
-      "title": "Failures, Retries, Recovery, Rate Limits",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 20
+        "y": 8
       },
       "id": 5,
       "options": {
@@ -398,12 +264,30 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "jvm_memory_used_bytes{job=\"order-service\", area=\"heap\"}",
-          "legendFormat": "{{id}}",
+          "expr": "rate(pg_stat_database_tup_inserted{datname=\"outbox\"}[5m])",
+          "legendFormat": "inserted",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(pg_stat_database_tup_updated{datname=\"outbox\"}[5m])",
+          "legendFormat": "updated",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(pg_stat_database_tup_deleted{datname=\"outbox\"}[5m])",
+          "legendFormat": "deleted",
+          "refId": "C"
         }
       ],
-      "title": "JVM Heap Used",
+      "title": "Row Operations / sec",
       "type": "timeseries"
     },
     {
@@ -416,15 +300,17 @@
           "color": {
             "mode": "palette-classic"
           },
-          "unit": "reqps"
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 20
+        "w": 8,
+        "x": 0,
+        "y": 16
       },
       "id": 6,
       "options": {
@@ -442,21 +328,205 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(http_server_requests_seconds_count{job=\"order-service\"}[5m])) by (uri, status)",
-          "legendFormat": "{{uri}} {{status}}",
+          "expr": "rate(pg_stat_database_blks_hit{datname=\"outbox\"}[5m]) / (rate(pg_stat_database_blks_hit{datname=\"outbox\"}[5m]) + rate(pg_stat_database_blks_read{datname=\"outbox\"}[5m]))",
+          "legendFormat": "cache hit ratio",
           "refId": "A"
         }
       ],
-      "title": "HTTP Request Rate",
+      "title": "Buffer Cache Hit Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(pg_stat_database_deadlocks{datname=\"outbox\"}[5m])",
+          "legendFormat": "deadlocks",
+          "refId": "A"
+        }
+      ],
+      "title": "Deadlocks / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(pg_locks_count) by (mode)",
+          "legendFormat": "{{mode}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Locks by Mode",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(pg_stat_activity_count) by (state)",
+          "legendFormat": "{{state}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sessions by State",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(pg_stat_database_tup_returned{datname=\"outbox\"}[5m])",
+          "legendFormat": "rows returned",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(pg_stat_database_tup_fetched{datname=\"outbox\"}[5m])",
+          "legendFormat": "rows fetched",
+          "refId": "B"
+        }
+      ],
+      "title": "Read Throughput (rows / sec)",
       "type": "timeseries"
     }
   ],
   "refresh": "10s",
   "schemaVersion": 39,
   "tags": [
-    "outbox",
-    "kafka",
-    "spring-boot"
+    "postgres",
+    "database"
   ],
   "templating": {
     "list": []
@@ -467,7 +537,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Transactional Outbox",
-  "uid": "transactional-outbox",
-  "version": 3
+  "title": "PostgreSQL",
+  "uid": "postgresql",
+  "version": 1
 }

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: order-service
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+
+  - job_name: notification-stub
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['host.docker.internal:8081']

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -12,3 +12,7 @@ scrape_configs:
     metrics_path: /actuator/prometheus
     static_configs:
       - targets: ['host.docker.internal:8081']
+
+  - job_name: postgres
+    static_configs:
+      - targets: ['postgres-exporter:9187']

--- a/notification-stub/pom.xml
+++ b/notification-stub/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/notification-stub/pom.xml
+++ b/notification-stub/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>

--- a/notification-stub/pom.xml
+++ b/notification-stub/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
@@ -31,8 +35,16 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/notification-stub/src/main/java/com/kholodilin/outbox/config/KafkaConsumerConfig.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/config/KafkaConsumerConfig.java
@@ -1,5 +1,9 @@
 package com.kholodilin.outbox.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.kholodilin.outbox.events.EventEnvelope;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -19,32 +23,40 @@ import java.util.Map;
 public class KafkaConsumerConfig {
 
     @Bean
-    public ConsumerFactory<String, com.kholodilin.outbox.events.EventEnvelope> consumerFactory(
+    public ConsumerFactory<String, EventEnvelope> consumerFactory(
             NotificationStubProperties properties,
             org.springframework.core.env.Environment environment
     ) {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, environment.getProperty("spring.kafka.bootstrap-servers"));
         config.put(ConsumerConfig.GROUP_ID_CONFIG, environment.getProperty("spring.kafka.consumer.group-id"));
-        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        config.put(JsonDeserializer.TRUSTED_PACKAGES, "com.kholodilin.outbox.events");
-        config.put(JsonDeserializer.VALUE_DEFAULT_TYPE, com.kholodilin.outbox.events.EventEnvelope.class.getName());
         config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100);
-        return new DefaultKafkaConsumerFactory<>(config);
+
+        JsonDeserializer<EventEnvelope> valueDeserializer = new JsonDeserializer<>(EventEnvelope.class, kafkaObjectMapper());
+        valueDeserializer.addTrustedPackages("com.kholodilin.outbox.events");
+        valueDeserializer.setUseTypeHeaders(false);
+
+        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(), valueDeserializer);
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, com.kholodilin.outbox.events.EventEnvelope> batchKafkaListenerContainerFactory(
-            ConsumerFactory<String, com.kholodilin.outbox.events.EventEnvelope> consumerFactory,
+    public ConcurrentKafkaListenerContainerFactory<String, EventEnvelope> batchKafkaListenerContainerFactory(
+            ConsumerFactory<String, EventEnvelope> consumerFactory,
             NotificationStubProperties properties
     ) {
-        ConcurrentKafkaListenerContainerFactory<String, com.kholodilin.outbox.events.EventEnvelope> factory =
+        ConcurrentKafkaListenerContainerFactory<String, EventEnvelope> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory);
         // Batch listener matches the publisher's batch-oriented throughput model.
         factory.setBatchListener(properties.getKafka().isBatchListener());
         return factory;
+    }
+
+    static ObjectMapper kafkaObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        return mapper;
     }
 }

--- a/notification-stub/src/main/java/com/kholodilin/outbox/config/NotificationStubProperties.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/config/NotificationStubProperties.java
@@ -16,6 +16,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @AllArgsConstructor
 public class NotificationStubProperties {
 
+    /** Kafka consumer settings for the notification stub. */
     @Builder.Default
     private Kafka kafka = Kafka.builder().build();
 
@@ -27,9 +28,11 @@ public class NotificationStubProperties {
     @AllArgsConstructor
     public static class Kafka {
 
+        /** Topic consumed by the notification stub. */
         @Builder.Default
         private String topic = "orders.events";
 
+        /** When {@code true}, the listener receives batches of {@link com.kholodilin.outbox.events.EventEnvelope}. */
         @Builder.Default
         private boolean batchListener = true;
     }

--- a/notification-stub/src/main/java/com/kholodilin/outbox/config/NotificationStubProperties.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/config/NotificationStubProperties.java
@@ -1,40 +1,36 @@
 package com.kholodilin.outbox.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Typed configuration bound from {@code app.*} keys in notification-stub application.yml. */
 @ConfigurationProperties(prefix = "app")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class NotificationStubProperties {
 
-    private Kafka kafka = new Kafka();
-
-    public Kafka getKafka() {
-        return kafka;
-    }
-
-    public void setKafka(Kafka kafka) {
-        this.kafka = kafka;
-    }
+    @Builder.Default
+    private Kafka kafka = Kafka.builder().build();
 
     /** Kafka consumer topic and batch-listener toggle. */
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Kafka {
+
+        @Builder.Default
         private String topic = "orders.events";
+
+        @Builder.Default
         private boolean batchListener = true;
-
-        public String getTopic() {
-            return topic;
-        }
-
-        public void setTopic(String topic) {
-            this.topic = topic;
-        }
-
-        public boolean isBatchListener() {
-            return batchListener;
-        }
-
-        public void setBatchListener(boolean batchListener) {
-            this.batchListener = batchListener;
-        }
     }
 }

--- a/notification-stub/src/main/java/com/kholodilin/outbox/metrics/NotificationStubMetrics.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/metrics/NotificationStubMetrics.java
@@ -1,0 +1,27 @@
+package com.kholodilin.outbox.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+/** Micrometer metrics for the notification stub Kafka consumer. */
+@Component
+public class NotificationStubMetrics {
+
+    private final Counter eventsReceived;
+    private final Counter batchesReceived;
+    private final Timer batchProcessing;
+
+    public NotificationStubMetrics(MeterRegistry registry) {
+        this.eventsReceived = Counter.builder("notification.events.received").register(registry);
+        this.batchesReceived = Counter.builder("notification.batches.received").register(registry);
+        this.batchProcessing = Timer.builder("notification.batch.processing").register(registry);
+    }
+
+    public void recordBatch(int batchSize, Runnable processing) {
+        batchesReceived.increment();
+        eventsReceived.increment(batchSize);
+        batchProcessing.record(processing);
+    }
+}

--- a/notification-stub/src/main/java/com/kholodilin/outbox/notification/NotificationStubHandler.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/notification/NotificationStubHandler.java
@@ -1,6 +1,7 @@
 package com.kholodilin.outbox.notification;
 
 import com.kholodilin.outbox.events.EventEnvelope;
+import com.kholodilin.outbox.metrics.NotificationStubMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -16,20 +17,26 @@ import java.util.List;
 @Component
 public class NotificationStubHandler {
 
+    private final NotificationStubMetrics metrics;
+
+    public NotificationStubHandler(NotificationStubMetrics metrics) {
+        this.metrics = metrics;
+    }
+
     @KafkaListener(
             topics = "${app.kafka.topic}",
             containerFactory = "batchKafkaListenerContainerFactory"
     )
     public void handleBatch(List<EventEnvelope> events) {
-        long start = System.nanoTime();
-        log.info("Notification stub batch received size={}", events.size());
-        for (EventEnvelope event : events) {
-            log.info("Notification stub sent orderId={} customerId={} eventId={}",
-                    event.getOrderId(), event.getCustomerId(), event.getEventId());
-            log.debug("Notification stub event details eventType={} correlationId={} payload={}",
-                    event.getEventType(), event.getCorrelationId(), event.getPayload());
-        }
-        long durationMs = (System.nanoTime() - start) / 1_000_000;
-        log.info("Notification stub batch processed size={} durationMs={}", events.size(), durationMs);
+        metrics.recordBatch(events.size(), () -> {
+            log.info("Notification stub batch received size={}", events.size());
+            for (EventEnvelope event : events) {
+                log.info("Notification stub sent orderId={} customerId={} eventId={}",
+                        event.getOrderId(), event.getCustomerId(), event.getEventId());
+                log.debug("Notification stub event details eventType={} correlationId={} payload={}",
+                        event.getEventType(), event.getCorrelationId(), event.getPayload());
+            }
+            log.info("Notification stub batch processed size={}", events.size());
+        });
     }
 }

--- a/notification-stub/src/main/resources/application-dev.yml
+++ b/notification-stub/src/main/resources/application-dev.yml
@@ -1,3 +1,8 @@
 logging:
   level:
     com.kholodilin.outbox: DEBUG
+
+spring:
+  kafka:
+    consumer:
+      group-id: notification-stub-dev

--- a/notification-stub/src/main/resources/application.yml
+++ b/notification-stub/src/main/resources/application.yml
@@ -17,7 +17,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,metrics
+        include: health,metrics,prometheus
 
 logging:
   level:

--- a/notification-stub/src/test/java/com/kholodilin/outbox/config/KafkaConsumerConfigTest.java
+++ b/notification-stub/src/test/java/com/kholodilin/outbox/config/KafkaConsumerConfigTest.java
@@ -1,0 +1,34 @@
+package com.kholodilin.outbox.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kholodilin.outbox.events.EventEnvelope;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaConsumerConfigTest {
+
+    @Test
+    void deserializesInstantFromIso8601() throws Exception {
+        ObjectMapper mapper = KafkaConsumerConfig.kafkaObjectMapper();
+        String json = """
+                {
+                  "eventId": 1,
+                  "orderId": 10,
+                  "customerId": 20,
+                  "eventType": "OrderCreated",
+                  "payload": {"orderId": 10},
+                  "occurredAt": "2026-07-12T10:15:30Z"
+                }
+                """;
+
+        EventEnvelope envelope = mapper.readValue(json, EventEnvelope.class);
+
+        assertThat(envelope.getEventId()).isEqualTo(1L);
+        assertThat(envelope.getOccurredAt()).isEqualTo(Instant.parse("2026-07-12T10:15:30Z"));
+        assertThat(envelope.getPayload()).containsEntry("orderId", 10);
+    }
+}

--- a/notification-stub/src/test/java/com/kholodilin/outbox/metrics/NotificationStubMetricsTest.java
+++ b/notification-stub/src/test/java/com/kholodilin/outbox/metrics/NotificationStubMetricsTest.java
@@ -1,0 +1,22 @@
+package com.kholodilin.outbox.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificationStubMetricsTest {
+
+    @Test
+    void recordsBatchMetrics() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        NotificationStubMetrics metrics = new NotificationStubMetrics(registry);
+
+        metrics.recordBatch(3, () -> {
+        });
+
+        assertThat(registry.find("notification.batches.received").counter().count()).isEqualTo(1.0);
+        assertThat(registry.find("notification.events.received").counter().count()).isEqualTo(3.0);
+        assertThat(registry.find("notification.batch.processing").timer().count()).isEqualTo(1);
+    }
+}

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -117,6 +117,32 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*IT.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -39,12 +39,20 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.liquibase</groupId>
-            <artifactId>liquibase-core</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-liquibase</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/order-service/src/main/java/com/kholodilin/outbox/config/AppConfig.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/AppConfig.java
@@ -5,8 +5,6 @@ import tools.jackson.databind.ObjectMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 /** Spring beans shared by the order service (JSON mapper, Kafka producer template). */
@@ -18,10 +16,5 @@ public class AppConfig {
     @Bean
     public ObjectMapper objectMapper() {
         return JsonMapper.builder().build();
-    }
-
-    @Bean
-    public KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> producerFactory) {
-        return new KafkaTemplate<>(producerFactory);
     }
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/AppProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/AppProperties.java
@@ -20,15 +20,19 @@ public class AppProperties {
     @Builder.Default
     private String instanceId = "local";
 
+    /** Kafka topic and related producer settings. */
     @Builder.Default
     private KafkaProperties kafka = KafkaProperties.builder().build();
 
+    /** In-memory queue, publisher, and recovery worker settings. */
     @Builder.Default
     private OutboxProperties outbox = OutboxProperties.builder().build();
 
+    /** HTTP rate-limit buckets and adaptive throttling settings. */
     @Builder.Default
     private RateLimitProperties rateLimit = RateLimitProperties.builder().build();
 
+    /** Thresholds used by custom Actuator health indicators. */
     @Builder.Default
     private HealthProperties health = HealthProperties.builder().build();
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/AppProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/AppProperties.java
@@ -1,55 +1,34 @@
 package com.kholodilin.outbox.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Typed configuration bound from {@code app.*} keys in application.yml. */
 @ConfigurationProperties(prefix = "app")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AppProperties {
 
     /** Unique pod/instance id used as {@code locked_by} for outbox leases. */
+    @Builder.Default
     private String instanceId = "local";
-    private KafkaProperties kafka = new KafkaProperties();
-    private OutboxProperties outbox = new OutboxProperties();
-    private RateLimitProperties rateLimit = new RateLimitProperties();
-    private HealthProperties health = new HealthProperties();
 
-    public String getInstanceId() {
-        return instanceId;
-    }
+    @Builder.Default
+    private KafkaProperties kafka = KafkaProperties.builder().build();
 
-    public void setInstanceId(String instanceId) {
-        this.instanceId = instanceId;
-    }
+    @Builder.Default
+    private OutboxProperties outbox = OutboxProperties.builder().build();
 
-    public KafkaProperties getKafka() {
-        return kafka;
-    }
+    @Builder.Default
+    private RateLimitProperties rateLimit = RateLimitProperties.builder().build();
 
-    public void setKafka(KafkaProperties kafka) {
-        this.kafka = kafka;
-    }
-
-    public OutboxProperties getOutbox() {
-        return outbox;
-    }
-
-    public void setOutbox(OutboxProperties outbox) {
-        this.outbox = outbox;
-    }
-
-    public RateLimitProperties getRateLimit() {
-        return rateLimit;
-    }
-
-    public void setRateLimit(RateLimitProperties rateLimit) {
-        this.rateLimit = rateLimit;
-    }
-
-    public HealthProperties getHealth() {
-        return health;
-    }
-
-    public void setHealth(HealthProperties health) {
-        this.health = health;
-    }
+    @Builder.Default
+    private HealthProperties health = HealthProperties.builder().build();
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/HealthProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/HealthProperties.java
@@ -14,9 +14,11 @@ import lombok.Setter;
 @AllArgsConstructor
 public class HealthProperties {
 
+    /** Queue fill ratio at or above which the queue health indicator reports DOWN. */
     @Builder.Default
     private double queuePressureCritical = 0.95;
 
+    /** Active outbox row count at or above which the outbox health indicator reports DOWN. */
     @Builder.Default
     private long outboxPendingCritical = 10000;
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/HealthProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/HealthProperties.java
@@ -1,24 +1,22 @@
 package com.kholodilin.outbox.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 /** Thresholds for Actuator health indicators (queue pressure, pending outbox rows). */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class HealthProperties {
 
+    @Builder.Default
     private double queuePressureCritical = 0.95;
+
+    @Builder.Default
     private long outboxPendingCritical = 10000;
-
-    public double getQueuePressureCritical() {
-        return queuePressureCritical;
-    }
-
-    public void setQueuePressureCritical(double queuePressureCritical) {
-        this.queuePressureCritical = queuePressureCritical;
-    }
-
-    public long getOutboxPendingCritical() {
-        return outboxPendingCritical;
-    }
-
-    public void setOutboxPendingCritical(long outboxPendingCritical) {
-        this.outboxPendingCritical = outboxPendingCritical;
-    }
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/KafkaProducerConfig.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/KafkaProducerConfig.java
@@ -1,0 +1,46 @@
+package com.kholodilin.outbox.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Kafka producer with Jackson 2 JsonSerializer (JavaTimeModule for {@code Instant} in {@link com.kholodilin.outbox.events.EventEnvelope}). */
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory(Environment environment) {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, environment.getProperty("spring.kafka.bootstrap-servers"));
+        config.put(ProducerConfig.ACKS_CONFIG, environment.getProperty("spring.kafka.producer.acks", "all"));
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        JsonSerializer<Object> valueSerializer = new JsonSerializer<>(kafkaObjectMapper());
+        valueSerializer.setAddTypeInfo(false);
+        return new DefaultKafkaProducerFactory<>(config, new StringSerializer(), valueSerializer);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+
+    static ObjectMapper kafkaObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+}

--- a/order-service/src/main/java/com/kholodilin/outbox/config/KafkaProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/KafkaProperties.java
@@ -1,15 +1,19 @@
 package com.kholodilin.outbox.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 /** Kafka topic and publisher settings. */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class KafkaProperties {
 
+    @Builder.Default
     private String topic = "orders.events";
-
-    public String getTopic() {
-        return topic;
-    }
-
-    public void setTopic(String topic) {
-        this.topic = topic;
-    }
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/KafkaProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/KafkaProperties.java
@@ -14,6 +14,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class KafkaProperties {
 
+    /** Target topic for outbox events published by {@code order-service}. */
     @Builder.Default
     private String topic = "orders.events";
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/MemoryQueueProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/MemoryQueueProperties.java
@@ -1,44 +1,30 @@
 package com.kholodilin.outbox.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.time.Duration;
 
 /** Bounded per-pod queue between DB commit and Kafka publish. */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MemoryQueueProperties {
 
+    @Builder.Default
     private int capacity = 10000;
+
+    @Builder.Default
     private int batchSize = 100;
+
+    @Builder.Default
     private Duration batchWait = Duration.ofMillis(50);
+
+    @Builder.Default
     private double usageThreshold = 0.8;
-
-    public int getCapacity() {
-        return capacity;
-    }
-
-    public void setCapacity(int capacity) {
-        this.capacity = capacity;
-    }
-
-    public int getBatchSize() {
-        return batchSize;
-    }
-
-    public void setBatchSize(int batchSize) {
-        this.batchSize = batchSize;
-    }
-
-    public Duration getBatchWait() {
-        return batchWait;
-    }
-
-    public void setBatchWait(Duration batchWait) {
-        this.batchWait = batchWait;
-    }
-
-    public double getUsageThreshold() {
-        return usageThreshold;
-    }
-
-    public void setUsageThreshold(double usageThreshold) {
-        this.usageThreshold = usageThreshold;
-    }
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/MemoryQueueProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/MemoryQueueProperties.java
@@ -16,15 +16,19 @@ import java.time.Duration;
 @AllArgsConstructor
 public class MemoryQueueProperties {
 
+    /** Maximum number of event ids held in memory before enqueue is rejected. */
     @Builder.Default
     private int capacity = 10000;
 
+    /** Maximum ids drained into one publisher batch after the first poll. */
     @Builder.Default
     private int batchSize = 100;
 
+    /** Time to wait for the first id before the publisher loop continues. */
     @Builder.Default
     private Duration batchWait = Duration.ofMillis(50);
 
+    /** Queue fill ratio above which adaptive rate limiting starts throttling. */
     @Builder.Default
     private double usageThreshold = 0.8;
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/OutboxProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/OutboxProperties.java
@@ -1,33 +1,25 @@
 package com.kholodilin.outbox.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 /** In-memory queue, publisher worker, and recovery worker tuning. */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class OutboxProperties {
 
-    private MemoryQueueProperties memoryQueue = new MemoryQueueProperties();
-    private PublisherProperties publisher = new PublisherProperties();
-    private RecoveryProperties recovery = new RecoveryProperties();
+    @Builder.Default
+    private MemoryQueueProperties memoryQueue = MemoryQueueProperties.builder().build();
 
-    public MemoryQueueProperties getMemoryQueue() {
-        return memoryQueue;
-    }
+    @Builder.Default
+    private PublisherProperties publisher = PublisherProperties.builder().build();
 
-    public void setMemoryQueue(MemoryQueueProperties memoryQueue) {
-        this.memoryQueue = memoryQueue;
-    }
-
-    public PublisherProperties getPublisher() {
-        return publisher;
-    }
-
-    public void setPublisher(PublisherProperties publisher) {
-        this.publisher = publisher;
-    }
-
-    public RecoveryProperties getRecovery() {
-        return recovery;
-    }
-
-    public void setRecovery(RecoveryProperties recovery) {
-        this.recovery = recovery;
-    }
+    @Builder.Default
+    private RecoveryProperties recovery = RecoveryProperties.builder().build();
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/OutboxProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/OutboxProperties.java
@@ -14,12 +14,15 @@ import lombok.Setter;
 @AllArgsConstructor
 public class OutboxProperties {
 
+    /** Per-pod hot queue between PostgreSQL commit and Kafka publish. */
     @Builder.Default
     private MemoryQueueProperties memoryQueue = MemoryQueueProperties.builder().build();
 
+    /** Background worker that claims rows and publishes batches to Kafka. */
     @Builder.Default
     private PublisherProperties publisher = PublisherProperties.builder().build();
 
+    /** Scheduled worker that re-enqueues stuck outbox rows. */
     @Builder.Default
     private RecoveryProperties recovery = RecoveryProperties.builder().build();
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/PublisherProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/PublisherProperties.java
@@ -1,35 +1,27 @@
 package com.kholodilin.outbox.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.time.Duration;
 
 /** Batch publisher lease, retry, and poll interval. */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PublisherProperties {
 
+    @Builder.Default
     private Duration leaseDuration = Duration.ofSeconds(30);
+
+    @Builder.Default
     private int maxRetries = 5;
+
+    @Builder.Default
     private Duration pollInterval = Duration.ofMillis(100);
-
-    public Duration getLeaseDuration() {
-        return leaseDuration;
-    }
-
-    public void setLeaseDuration(Duration leaseDuration) {
-        this.leaseDuration = leaseDuration;
-    }
-
-    public int getMaxRetries() {
-        return maxRetries;
-    }
-
-    public void setMaxRetries(int maxRetries) {
-        this.maxRetries = maxRetries;
-    }
-
-    public Duration getPollInterval() {
-        return pollInterval;
-    }
-
-    public void setPollInterval(Duration pollInterval) {
-        this.pollInterval = pollInterval;
-    }
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/PublisherProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/PublisherProperties.java
@@ -16,12 +16,15 @@ import java.time.Duration;
 @AllArgsConstructor
 public class PublisherProperties {
 
+    /** How long a pod keeps an exclusive lease on claimed outbox rows. */
     @Builder.Default
     private Duration leaseDuration = Duration.ofSeconds(30);
 
+    /** Failed publish attempts after which a row is moved to {@code DEAD}. */
     @Builder.Default
     private int maxRetries = 5;
 
+    /** Reserved poll interval for future publisher tuning. */
     @Builder.Default
     private Duration pollInterval = Duration.ofMillis(100);
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/RateLimitBucketProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/RateLimitBucketProperties.java
@@ -14,6 +14,9 @@ import lombok.Setter;
 @AllArgsConstructor
 public class RateLimitBucketProperties {
 
+    /** Maximum number of tokens the bucket can hold (burst size). */
     private long capacity;
+
+    /** Tokens added to the bucket per second under normal conditions. */
     private long refillPerSecond;
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/RateLimitBucketProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/RateLimitBucketProperties.java
@@ -1,32 +1,19 @@
 package com.kholodilin.outbox.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 /** Token-bucket capacity and refill rate for rate limiting. */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RateLimitBucketProperties {
 
     private long capacity;
     private long refillPerSecond;
-
-    public RateLimitBucketProperties() {
-    }
-
-    public RateLimitBucketProperties(long capacity, long refillPerSecond) {
-        this.capacity = capacity;
-        this.refillPerSecond = refillPerSecond;
-    }
-
-    public long getCapacity() {
-        return capacity;
-    }
-
-    public void setCapacity(long capacity) {
-        this.capacity = capacity;
-    }
-
-    public long getRefillPerSecond() {
-        return refillPerSecond;
-    }
-
-    public void setRefillPerSecond(long refillPerSecond) {
-        this.refillPerSecond = refillPerSecond;
-    }
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/RateLimitProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/RateLimitProperties.java
@@ -1,42 +1,28 @@
 package com.kholodilin.outbox.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 /** Token-bucket limits with adaptive backpressure when queue pressure is high. */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RateLimitProperties {
 
+    @Builder.Default
     private double throttleMultiplier = 0.5;
-    private RateLimitBucketProperties global = new RateLimitBucketProperties(1000, 100);
-    private RateLimitBucketProperties perCustomer = new RateLimitBucketProperties(100, 10);
-    private RateLimitBucketProperties perIp = new RateLimitBucketProperties(50, 5);
 
-    public double getThrottleMultiplier() {
-        return throttleMultiplier;
-    }
+    @Builder.Default
+    private RateLimitBucketProperties global = RateLimitBucketProperties.builder().capacity(1000).refillPerSecond(100).build();
 
-    public void setThrottleMultiplier(double throttleMultiplier) {
-        this.throttleMultiplier = throttleMultiplier;
-    }
+    @Builder.Default
+    private RateLimitBucketProperties perCustomer = RateLimitBucketProperties.builder().capacity(100).refillPerSecond(10).build();
 
-    public RateLimitBucketProperties getGlobal() {
-        return global;
-    }
-
-    public void setGlobal(RateLimitBucketProperties global) {
-        this.global = global;
-    }
-
-    public RateLimitBucketProperties getPerCustomer() {
-        return perCustomer;
-    }
-
-    public void setPerCustomer(RateLimitBucketProperties perCustomer) {
-        this.perCustomer = perCustomer;
-    }
-
-    public RateLimitBucketProperties getPerIp() {
-        return perIp;
-    }
-
-    public void setPerIp(RateLimitBucketProperties perIp) {
-        this.perIp = perIp;
-    }
+    @Builder.Default
+    private RateLimitBucketProperties perIp = RateLimitBucketProperties.builder().capacity(50).refillPerSecond(5).build();
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/RateLimitProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/RateLimitProperties.java
@@ -14,15 +14,19 @@ import lombok.Setter;
 @AllArgsConstructor
 public class RateLimitProperties {
 
+    /** Multiplier applied to bucket refill rates while the queue is under pressure. */
     @Builder.Default
     private double throttleMultiplier = 0.5;
 
+    /** Cluster-wide request rate limit. */
     @Builder.Default
     private RateLimitBucketProperties global = RateLimitBucketProperties.builder().capacity(1000).refillPerSecond(100).build();
 
+    /** Per-customer request rate limit. */
     @Builder.Default
     private RateLimitBucketProperties perCustomer = RateLimitBucketProperties.builder().capacity(100).refillPerSecond(10).build();
 
+    /** Per client IP request rate limit. */
     @Builder.Default
     private RateLimitBucketProperties perIp = RateLimitBucketProperties.builder().capacity(50).refillPerSecond(5).build();
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/RecoveryProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/RecoveryProperties.java
@@ -1,35 +1,27 @@
 package com.kholodilin.outbox.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.time.Duration;
 
 /** Scheduled scan of stuck ACTIVE rows — enqueue only, never publishes directly. */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RecoveryProperties {
 
+    @Builder.Default
     private boolean enabled = true;
+
+    @Builder.Default
     private Duration interval = Duration.ofSeconds(10);
+
+    @Builder.Default
     private int batchSize = 500;
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public Duration getInterval() {
-        return interval;
-    }
-
-    public void setInterval(Duration interval) {
-        this.interval = interval;
-    }
-
-    public int getBatchSize() {
-        return batchSize;
-    }
-
-    public void setBatchSize(int batchSize) {
-        this.batchSize = batchSize;
-    }
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/config/RecoveryProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/RecoveryProperties.java
@@ -16,12 +16,15 @@ import java.time.Duration;
 @AllArgsConstructor
 public class RecoveryProperties {
 
+    /** Whether the recovery scheduler is active. */
     @Builder.Default
     private boolean enabled = true;
 
+    /** Delay between recovery scans after the previous run completes. */
     @Builder.Default
     private Duration interval = Duration.ofSeconds(10);
 
+    /** Maximum number of outbox ids claimed and re-enqueued per scan. */
     @Builder.Default
     private int batchSize = 500;
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/IdempotencyJdbcRepository.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/IdempotencyJdbcRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -61,8 +62,8 @@ public class IdempotencyJdbcRepository {
                 idempotencyKey,
                 requestHash,
                 IdempotencyStatus.PROCESSING.getCode(),
-                now,
-                now
+                Timestamp.from(now),
+                Timestamp.from(now)
         );
     }
 
@@ -75,7 +76,7 @@ public class IdempotencyJdbcRepository {
                         """,
                 IdempotencyStatus.COMPLETED.getCode(),
                 responseBody,
-                now,
+                Timestamp.from(now),
                 customerId,
                 idempotencyKey
         );

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/OrderJdbcRepository.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/OrderJdbcRepository.java
@@ -4,6 +4,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.time.Instant;
 
 /**
@@ -32,8 +33,8 @@ public class OrderJdbcRepository {
                 customerId,
                 "CREATED",
                 totalAmount,
-                now,
-                now
+                Timestamp.from(now),
+                Timestamp.from(now)
         );
         return id;
     }
@@ -49,7 +50,7 @@ public class OrderJdbcRepository {
                 productId,
                 quantity,
                 price,
-                now
+                Timestamp.from(now)
         );
     }
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxJdbcRepository.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxJdbcRepository.java
@@ -24,30 +24,18 @@ import java.util.Map;
 @Repository
 public class OutboxJdbcRepository {
 
-    /** Lightweight row loaded for publishing — payload kept as JSON string until send time. */
-    public record OutboxRow(
-            Long id,
-            Long orderId,
-            Long customerId,
-            String eventType,
-            String payload,
-            OutboxStatus status,
-            int retryCount
-    ) {
-    }
-
     private static final RowMapper<OutboxRow> ROW_MAPPER = new RowMapper<>() {
         @Override
         public OutboxRow mapRow(ResultSet rs, int rowNum) throws SQLException {
-            return new OutboxRow(
-                    rs.getLong("id"),
-                    rs.getLong("order_id"),
-                    rs.getLong("customer_id"),
-                    rs.getString("event_type"),
-                    rs.getString("payload"),
-                    OutboxStatus.fromCode(rs.getInt("status")),
-                    rs.getInt("retry_count")
-            );
+            return OutboxRow.builder()
+                    .id(rs.getLong("id"))
+                    .orderId(rs.getLong("order_id"))
+                    .customerId(rs.getLong("customer_id"))
+                    .eventType(rs.getString("event_type"))
+                    .payload(rs.getString("payload"))
+                    .status(OutboxStatus.fromCode(rs.getInt("status")))
+                    .retryCount(rs.getInt("retry_count"))
+                    .build();
         }
     };
 
@@ -195,18 +183,18 @@ public class OutboxJdbcRepository {
     public EventEnvelope toEnvelope(OutboxRow row, String correlationId) {
         try {
             @SuppressWarnings("unchecked")
-            Map<String, Object> payload = objectMapper.readValue(row.payload(), Map.class);
+            Map<String, Object> payload = objectMapper.readValue(row.getPayload(), Map.class);
             return EventEnvelope.builder()
-                    .eventId(row.id())
-                    .orderId(row.orderId())
-                    .customerId(row.customerId())
-                    .eventType(row.eventType())
+                    .eventId(row.getId())
+                    .orderId(row.getOrderId())
+                    .customerId(row.getCustomerId())
+                    .eventType(row.getEventType())
                     .payload(payload)
                     .correlationId(correlationId)
                     .occurredAt(Instant.now())
                     .build();
         } catch (Exception ex) {
-            throw new IllegalStateException("Failed to parse outbox payload for id=" + row.id(), ex);
+            throw new IllegalStateException("Failed to parse outbox payload for id=" + row.getId(), ex);
         }
     }
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxJdbcRepository.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxJdbcRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +72,7 @@ public class OutboxJdbcRepository {
                 eventType,
                 payload,
                 OutboxStatus.NEW.getCode(),
-                now
+                Timestamp.from(now)
         );
         return id;
     }
@@ -88,11 +89,9 @@ public class OutboxJdbcRepository {
         List<Object> params = new ArrayList<>();
         params.add(OutboxStatus.PROCESSING.getCode());
         params.add(lockedBy);
-        params.add(lockedUntil);
+        params.add(Timestamp.from(lockedUntil));
         params.addAll(ids);
         params.add(OutboxStatus.ARCHIVE_THRESHOLD);
-        params.add(OutboxStatus.NEW.getCode());
-        params.add(OutboxStatus.FAILED.getCode());
 
         return jdbcTemplate.query(
                 """
@@ -100,7 +99,6 @@ public class OutboxJdbcRepository {
                         SET status = ?, locked_by = ?, locked_until = ?
                         WHERE id IN (%s)
                           AND status < ?
-                          AND status IN (?, ?)
                           AND (locked_until IS NULL OR locked_until < NOW())
                         RETURNING id, order_id, customer_id, event_type, payload::text AS payload, status, retry_count
                         """.formatted(placeholders),
@@ -116,7 +114,7 @@ public class OutboxJdbcRepository {
         String placeholders = String.join(",", ids.stream().map(id -> "?").toList());
         List<Object> params = new ArrayList<>();
         params.add(OutboxStatus.SENT.getCode());
-        params.add(sentAt);
+        params.add(Timestamp.from(sentAt));
         params.addAll(ids);
         jdbcTemplate.update(
                 """
@@ -149,7 +147,6 @@ public class OutboxJdbcRepository {
                             SELECT id
                             FROM outbox_events
                             WHERE status < ?
-                              AND status IN (?, ?)
                               AND (locked_until IS NULL OR locked_until < NOW())
                             ORDER BY id
                             LIMIT ?
@@ -164,11 +161,9 @@ public class OutboxJdbcRepository {
                         """,
                 (rs, rowNum) -> rs.getLong("id"),
                 OutboxStatus.ARCHIVE_THRESHOLD,
-                OutboxStatus.NEW.getCode(),
-                OutboxStatus.FAILED.getCode(),
                 batchSize,
                 lockedBy,
-                lockedUntil
+                Timestamp.from(lockedUntil)
         );
     }
 

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxRow.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxRow.java
@@ -1,0 +1,21 @@
+package com.kholodilin.outbox.persistence;
+
+import com.kholodilin.outbox.events.OutboxStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/** Lightweight row loaded for publishing — payload kept as JSON string until send time. */
+@Getter
+@Builder
+@AllArgsConstructor
+public class OutboxRow {
+
+    private final Long id;
+    private final Long orderId;
+    private final Long customerId;
+    private final String eventType;
+    private final String payload;
+    private final OutboxStatus status;
+    private final int retryCount;
+}

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxRow.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxRow.java
@@ -5,17 +5,34 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-/** Lightweight row loaded for publishing — payload kept as JSON string until send time. */
+/**
+ * Lightweight outbox row snapshot loaded for publishing.
+ * <p>
+ * Payload is kept as a JSON string until the publisher builds an {@link com.kholodilin.outbox.events.EventEnvelope}.
+ */
 @Getter
 @Builder
 @AllArgsConstructor
 public class OutboxRow {
 
+    /** Primary key of the {@code outbox_events} row. */
     private final Long id;
+
+    /** Foreign business key to the {@code orders} table. */
     private final Long orderId;
+
+    /** Customer identifier; also used as the Kafka partition key. */
     private final Long customerId;
+
+    /** Domain event name (for example {@code OrderCreated}). */
     private final String eventType;
+
+    /** Raw JSON payload as stored in PostgreSQL {@code jsonb}. */
     private final String payload;
+
+    /** Current lifecycle status after claim or recovery. */
     private final OutboxStatus status;
+
+    /** Number of failed publish attempts recorded for this row. */
     private final int retryCount;
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/IdempotencyKeyEntity.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/IdempotencyKeyEntity.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
@@ -35,7 +33,6 @@ public class IdempotencyKeyEntity {
     private Long customerId;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "idempotency_key", nullable = false)

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/IdempotencyKeyEntity.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/IdempotencyKeyEntity.java
@@ -8,7 +8,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -26,6 +29,9 @@ import java.time.Instant;
 @IdClass(IdempotencyKeyId.class)
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class IdempotencyKeyEntity {
 
     @Id

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/IdempotencyKeyId.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/IdempotencyKeyId.java
@@ -1,14 +1,20 @@
 package com.kholodilin.outbox.persistence.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.Serializable;
 
 /** Composite primary key for hash-partitioned {@link IdempotencyKeyEntity}. */
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
+@Setter
+@Builder
 @EqualsAndHashCode
 public class IdempotencyKeyId implements Serializable {
     private Long customerId;

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OrderEntity.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OrderEntity.java
@@ -5,7 +5,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.math.BigDecimal;
@@ -22,6 +25,9 @@ import java.time.Instant;
 @IdClass(OrderId.class)
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class OrderEntity {
 
     @Id

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OrderEntity.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OrderEntity.java
@@ -2,8 +2,6 @@ package com.kholodilin.outbox.persistence.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
@@ -31,7 +29,6 @@ public class OrderEntity {
     private Long customerId;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OrderId.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OrderId.java
@@ -1,14 +1,20 @@
 package com.kholodilin.outbox.persistence.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.Serializable;
 
 /** Composite primary key for hash-partitioned {@link OrderEntity}. */
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
+@Setter
+@Builder
 @EqualsAndHashCode
 public class OrderId implements Serializable {
     private Long customerId;

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OrderItemEntity.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OrderItemEntity.java
@@ -6,7 +6,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.math.BigDecimal;
@@ -22,6 +25,9 @@ import java.time.Instant;
 @Table(name = "order_items")
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class OrderItemEntity {
 
     @Id

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OutboxEventEntity.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OutboxEventEntity.java
@@ -5,7 +5,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -22,6 +25,9 @@ import java.time.Instant;
 @IdClass(OutboxEventId.class)
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class OutboxEventEntity {
 
     @Id

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OutboxEventEntity.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OutboxEventEntity.java
@@ -1,11 +1,7 @@
 package com.kholodilin.outbox.persistence.entity;
 
-import com.kholodilin.outbox.events.OutboxStatus;
 import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
@@ -29,12 +25,10 @@ import java.time.Instant;
 public class OutboxEventEntity {
 
     @Id
-    @Convert(converter = OutboxStatusConverter.class)
     @Column(nullable = false)
-    private OutboxStatus status;
+    private Integer status;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "order_id", nullable = false)

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OutboxEventId.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/entity/OutboxEventId.java
@@ -1,14 +1,20 @@
 package com.kholodilin.outbox.persistence.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.Serializable;
 
 /** Composite primary key for range-partitioned {@link OutboxEventEntity}. */
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
+@Setter
+@Builder
 @EqualsAndHashCode
 public class OutboxEventId implements Serializable {
     private Integer status;

--- a/order-service/src/main/java/com/kholodilin/outbox/publisher/BatchPublisherWorker.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/publisher/BatchPublisherWorker.java
@@ -6,6 +6,7 @@ import com.kholodilin.outbox.events.EventEnvelope;
 import com.kholodilin.outbox.events.OutboxStatus;
 import com.kholodilin.outbox.metrics.OutboxMetrics;
 import com.kholodilin.outbox.persistence.OutboxJdbcRepository;
+import com.kholodilin.outbox.persistence.OutboxRow;
 import com.kholodilin.outbox.queue.InMemoryEventQueue;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -89,7 +90,7 @@ public class BatchPublisherWorker {
 
                 // Multi-pod safety: only rows we successfully claim are published.
                 Instant lockedUntil = Instant.now().plus(properties.getOutbox().getPublisher().getLeaseDuration());
-                List<OutboxJdbcRepository.OutboxRow> claimed = outboxJdbcRepository.claimByIds(
+                List<OutboxRow> claimed = outboxJdbcRepository.claimByIds(
                         ids,
                         properties.getInstanceId(),
                         lockedUntil
@@ -100,15 +101,15 @@ public class BatchPublisherWorker {
                 }
 
                 List<EventEnvelope> envelopes = new ArrayList<>();
-                for (OutboxJdbcRepository.OutboxRow row : claimed) {
-                    String correlationId = extractCorrelationId(row.payload());
+                for (OutboxRow row : claimed) {
+                    String correlationId = extractCorrelationId(row.getPayload());
                     envelopes.add(outboxJdbcRepository.toEnvelope(row, correlationId));
                 }
 
                 long start = System.nanoTime();
                 try {
                     kafkaBatchPublisher.publish(envelopes);
-                    List<Long> sentIds = claimed.stream().map(OutboxJdbcRepository.OutboxRow::id).toList();
+                    List<Long> sentIds = claimed.stream().map(OutboxRow::getId).toList();
                     outboxJdbcRepository.markSent(sentIds, Instant.now());
                     metrics.publishLatency().record(System.nanoTime() - start, java.util.concurrent.TimeUnit.NANOSECONDS);
                     log.info("Kafka batch published size={} durationMs={}",
@@ -129,14 +130,14 @@ public class BatchPublisherWorker {
         }
     }
 
-    private void handleFailures(List<OutboxJdbcRepository.OutboxRow> claimed) {
+    private void handleFailures(List<OutboxRow> claimed) {
         int maxRetries = properties.getOutbox().getPublisher().getMaxRetries();
-        for (OutboxJdbcRepository.OutboxRow row : claimed) {
-            int nextRetry = row.retryCount() + 1;
+        for (OutboxRow row : claimed) {
+            int nextRetry = row.getRetryCount() + 1;
             metrics.incrementRetryCount();
             OutboxStatus status = nextRetry >= maxRetries ? OutboxStatus.DEAD : OutboxStatus.FAILED;
-            outboxJdbcRepository.markFailed(row.id(), nextRetry, status);
-            log.info("Outbox event marked {} eventId={} retryCount={}", status, row.id(), nextRetry);
+            outboxJdbcRepository.markFailed(row.getId(), nextRetry, status);
+            log.info("Outbox event marked {} eventId={} retryCount={}", status, row.getId(), nextRetry);
         }
     }
 

--- a/order-service/src/main/resources/application-dev.yml
+++ b/order-service/src/main/resources/application-dev.yml
@@ -1,3 +1,15 @@
 logging:
   level:
     com.kholodilin.outbox: DEBUG
+
+app:
+  rate-limit:
+    global:
+      capacity: 50000
+      refill-per-second: 5000
+    per-customer:
+      capacity: 5000
+      refill-per-second: 1000
+    per-ip:
+      capacity: 2000
+      refill-per-second: 500

--- a/order-service/src/test/java/com/kholodilin/outbox/OrderServiceApplicationIT.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/OrderServiceApplicationIT.java
@@ -8,7 +8,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @ActiveProfiles("test")
 @EmbeddedKafka(partitions = 1, topics = "orders.events")
-class OrderServiceApplicationTest {
+class OrderServiceApplicationIT {
 
     @Test
     void contextLoads() {

--- a/order-service/src/test/java/com/kholodilin/outbox/config/KafkaProducerConfigTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/config/KafkaProducerConfigTest.java
@@ -1,0 +1,31 @@
+package com.kholodilin.outbox.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kholodilin.outbox.events.EventEnvelope;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaProducerConfigTest {
+
+    @Test
+    void serializesInstantAsIso8601() throws Exception {
+        ObjectMapper mapper = KafkaProducerConfig.kafkaObjectMapper();
+        EventEnvelope envelope = EventEnvelope.builder()
+                .eventId(1L)
+                .orderId(10L)
+                .customerId(20L)
+                .eventType("OrderCreated")
+                .payload(Map.of("orderId", 10))
+                .occurredAt(Instant.parse("2026-07-12T10:15:30Z"))
+                .build();
+
+        String json = mapper.writeValueAsString(envelope);
+
+        assertThat(json).contains("2026-07-12T10:15:30Z");
+        assertThat(json).doesNotContain("1752305730");
+    }
+}

--- a/order-service/src/test/java/com/kholodilin/outbox/idempotency/IdempotencyServiceTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/idempotency/IdempotencyServiceTest.java
@@ -34,15 +34,16 @@ class IdempotencyServiceTest {
 
     @Test
     void returnsCachedCompletedResponse() throws Exception {
-        IdempotencyKeyEntity entity = new IdempotencyKeyEntity();
-        entity.setRequestHash("hash");
-        entity.setStatus(IdempotencyStatus.COMPLETED);
-        entity.setResponseBody(objectMapper.writeValueAsString(CreateOrderResponse.builder()
-                .orderId(1L)
-                .eventId(2L)
-                .status("ACCEPTED")
-                .createdAt(Instant.now())
-                .build()));
+        IdempotencyKeyEntity entity = IdempotencyKeyEntity.builder()
+                .requestHash("hash")
+                .status(IdempotencyStatus.COMPLETED)
+                .responseBody(objectMapper.writeValueAsString(CreateOrderResponse.builder()
+                        .orderId(1L)
+                        .eventId(2L)
+                        .status("ACCEPTED")
+                        .createdAt(Instant.now())
+                        .build()))
+                .build();
         when(repository.findByCustomerIdAndKey(1L, "key")).thenReturn(Optional.of(entity));
 
         Optional<CreateOrderResponse> response = service.findCachedResponse(1L, "key", "hash");
@@ -52,9 +53,10 @@ class IdempotencyServiceTest {
 
     @Test
     void throwsOnHashConflict() {
-        IdempotencyKeyEntity entity = new IdempotencyKeyEntity();
-        entity.setRequestHash("other");
-        entity.setStatus(IdempotencyStatus.COMPLETED);
+        IdempotencyKeyEntity entity = IdempotencyKeyEntity.builder()
+                .requestHash("other")
+                .status(IdempotencyStatus.COMPLETED)
+                .build();
         when(repository.findByCustomerIdAndKey(1L, "key")).thenReturn(Optional.of(entity));
 
         assertThatThrownBy(() -> service.findCachedResponse(1L, "key", "hash"))
@@ -63,9 +65,10 @@ class IdempotencyServiceTest {
 
     @Test
     void throwsWhenRequestIsStillProcessing() {
-        IdempotencyKeyEntity entity = new IdempotencyKeyEntity();
-        entity.setRequestHash("hash");
-        entity.setStatus(IdempotencyStatus.PROCESSING);
+        IdempotencyKeyEntity entity = IdempotencyKeyEntity.builder()
+                .requestHash("hash")
+                .status(IdempotencyStatus.PROCESSING)
+                .build();
         when(repository.findByCustomerIdAndKey(1L, "key")).thenReturn(Optional.of(entity));
 
         assertThatThrownBy(() -> service.findCachedResponse(1L, "key", "hash"))

--- a/order-service/src/test/java/com/kholodilin/outbox/idempotency/IdempotencyServiceTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/idempotency/IdempotencyServiceTest.java
@@ -60,4 +60,16 @@ class IdempotencyServiceTest {
         assertThatThrownBy(() -> service.findCachedResponse(1L, "key", "hash"))
                 .isInstanceOf(IdempotencyConflictException.class);
     }
+
+    @Test
+    void throwsWhenRequestIsStillProcessing() {
+        IdempotencyKeyEntity entity = new IdempotencyKeyEntity();
+        entity.setRequestHash("hash");
+        entity.setStatus(IdempotencyStatus.PROCESSING);
+        when(repository.findByCustomerIdAndKey(1L, "key")).thenReturn(Optional.of(entity));
+
+        assertThatThrownBy(() -> service.findCachedResponse(1L, "key", "hash"))
+                .isInstanceOf(IdempotencyConflictException.class)
+                .hasMessageContaining("already being processed");
+    }
 }

--- a/order-service/src/test/java/com/kholodilin/outbox/persistence/OutboxJdbcRepositoryTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/persistence/OutboxJdbcRepositoryTest.java
@@ -16,15 +16,15 @@ class OutboxJdbcRepositoryTest {
 
     @Test
     void toEnvelopeBuildsKafkaMessage() {
-        OutboxJdbcRepository.OutboxRow row = new OutboxJdbcRepository.OutboxRow(
-                1L,
-                99L,
-                10L,
-                "OrderCreated",
-                "{\"orderId\":99,\"customerId\":10}",
-                OutboxStatus.NEW,
-                0
-        );
+        OutboxRow row = OutboxRow.builder()
+                .id(1L)
+                .orderId(99L)
+                .customerId(10L)
+                .eventType("OrderCreated")
+                .payload("{\"orderId\":99,\"customerId\":10}")
+                .status(OutboxStatus.NEW)
+                .retryCount(0)
+                .build();
 
         EventEnvelope envelope = repository.toEnvelope(row, "corr-1");
 

--- a/order-service/src/test/java/com/kholodilin/outbox/persistence/OutboxJdbcRepositoryTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/persistence/OutboxJdbcRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.kholodilin.outbox.persistence;
+
+import tools.jackson.databind.json.JsonMapper;
+import com.kholodilin.outbox.events.EventEnvelope;
+import com.kholodilin.outbox.events.OutboxStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class OutboxJdbcRepositoryTest {
+
+    private final OutboxJdbcRepository repository =
+            new OutboxJdbcRepository(mock(JdbcTemplate.class), JsonMapper.builder().build());
+
+    @Test
+    void toEnvelopeBuildsKafkaMessage() {
+        OutboxJdbcRepository.OutboxRow row = new OutboxJdbcRepository.OutboxRow(
+                1L,
+                99L,
+                10L,
+                "OrderCreated",
+                "{\"orderId\":99,\"customerId\":10}",
+                OutboxStatus.NEW,
+                0
+        );
+
+        EventEnvelope envelope = repository.toEnvelope(row, "corr-1");
+
+        assertThat(envelope.getEventId()).isEqualTo(1L);
+        assertThat(envelope.getOrderId()).isEqualTo(99L);
+        assertThat(envelope.getCustomerId()).isEqualTo(10L);
+        assertThat(envelope.getEventType()).isEqualTo("OrderCreated");
+        assertThat(envelope.getCorrelationId()).isEqualTo("corr-1");
+        assertThat(envelope.getPayload()).containsEntry("orderId", 99);
+    }
+}

--- a/order-service/src/test/java/com/kholodilin/outbox/publisher/BatchPublisherWorkerTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/publisher/BatchPublisherWorkerTest.java
@@ -2,8 +2,11 @@ package com.kholodilin.outbox.publisher;
 
 import tools.jackson.databind.json.JsonMapper;
 import com.kholodilin.outbox.config.AppProperties;
+import com.kholodilin.outbox.config.OutboxProperties;
+import com.kholodilin.outbox.config.PublisherProperties;
 import com.kholodilin.outbox.events.OutboxStatus;
 import com.kholodilin.outbox.metrics.OutboxMetrics;
+import com.kholodilin.outbox.persistence.OutboxRow;
 import com.kholodilin.outbox.persistence.OutboxJdbcRepository;
 import com.kholodilin.outbox.queue.InMemoryEventQueue;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -34,8 +37,11 @@ class BatchPublisherWorkerTest {
 
     @BeforeEach
     void setUp() {
-        AppProperties properties = new AppProperties();
-        properties.getOutbox().getPublisher().setMaxRetries(5);
+        AppProperties properties = AppProperties.builder()
+                .outbox(OutboxProperties.builder()
+                        .publisher(PublisherProperties.builder().maxRetries(5).build())
+                        .build())
+                .build();
         worker = new BatchPublisherWorker(
                 eventQueue,
                 outboxJdbcRepository,
@@ -48,7 +54,7 @@ class BatchPublisherWorkerTest {
 
     @Test
     void marksFailedBeforeMaxRetries() {
-        OutboxJdbcRepository.OutboxRow row = sampleRow(2);
+        OutboxRow row = sampleRow(2);
 
         ReflectionTestUtils.invokeMethod(worker, "handleFailures", List.of(row));
 
@@ -57,22 +63,22 @@ class BatchPublisherWorkerTest {
 
     @Test
     void marksDeadAfterMaxRetries() {
-        OutboxJdbcRepository.OutboxRow row = sampleRow(4);
+        OutboxRow row = sampleRow(4);
 
         ReflectionTestUtils.invokeMethod(worker, "handleFailures", List.of(row));
 
         verify(outboxJdbcRepository).markFailed(1L, 5, OutboxStatus.DEAD);
     }
 
-    private OutboxJdbcRepository.OutboxRow sampleRow(int retryCount) {
-        return new OutboxJdbcRepository.OutboxRow(
-                1L,
-                10L,
-                20L,
-                "OrderCreated",
-                "{\"orderId\":10}",
-                OutboxStatus.PROCESSING,
-                retryCount
-        );
+    private OutboxRow sampleRow(int retryCount) {
+        return OutboxRow.builder()
+                .id(1L)
+                .orderId(10L)
+                .customerId(20L)
+                .eventType("OrderCreated")
+                .payload("{\"orderId\":10}")
+                .status(OutboxStatus.PROCESSING)
+                .retryCount(retryCount)
+                .build();
     }
 }

--- a/order-service/src/test/java/com/kholodilin/outbox/publisher/BatchPublisherWorkerTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/publisher/BatchPublisherWorkerTest.java
@@ -1,0 +1,78 @@
+package com.kholodilin.outbox.publisher;
+
+import tools.jackson.databind.json.JsonMapper;
+import com.kholodilin.outbox.config.AppProperties;
+import com.kholodilin.outbox.events.OutboxStatus;
+import com.kholodilin.outbox.metrics.OutboxMetrics;
+import com.kholodilin.outbox.persistence.OutboxJdbcRepository;
+import com.kholodilin.outbox.queue.InMemoryEventQueue;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class BatchPublisherWorkerTest {
+
+    @Mock
+    private InMemoryEventQueue eventQueue;
+
+    @Mock
+    private OutboxJdbcRepository outboxJdbcRepository;
+
+    @Mock
+    private KafkaBatchPublisher kafkaBatchPublisher;
+
+    private BatchPublisherWorker worker;
+
+    @BeforeEach
+    void setUp() {
+        AppProperties properties = new AppProperties();
+        properties.getOutbox().getPublisher().setMaxRetries(5);
+        worker = new BatchPublisherWorker(
+                eventQueue,
+                outboxJdbcRepository,
+                kafkaBatchPublisher,
+                new OutboxMetrics(new SimpleMeterRegistry()),
+                properties,
+                JsonMapper.builder().build()
+        );
+    }
+
+    @Test
+    void marksFailedBeforeMaxRetries() {
+        OutboxJdbcRepository.OutboxRow row = sampleRow(2);
+
+        ReflectionTestUtils.invokeMethod(worker, "handleFailures", List.of(row));
+
+        verify(outboxJdbcRepository).markFailed(1L, 3, OutboxStatus.FAILED);
+    }
+
+    @Test
+    void marksDeadAfterMaxRetries() {
+        OutboxJdbcRepository.OutboxRow row = sampleRow(4);
+
+        ReflectionTestUtils.invokeMethod(worker, "handleFailures", List.of(row));
+
+        verify(outboxJdbcRepository).markFailed(1L, 5, OutboxStatus.DEAD);
+    }
+
+    private OutboxJdbcRepository.OutboxRow sampleRow(int retryCount) {
+        return new OutboxJdbcRepository.OutboxRow(
+                1L,
+                10L,
+                20L,
+                "OrderCreated",
+                "{\"orderId\":10}",
+                OutboxStatus.PROCESSING,
+                retryCount
+        );
+    }
+}

--- a/order-service/src/test/java/com/kholodilin/outbox/queue/InMemoryEventQueueTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/queue/InMemoryEventQueueTest.java
@@ -47,4 +47,20 @@ class InMemoryEventQueueTest {
         assertThat(first).isEqualTo(1L);
         assertThat(drained).containsExactly(2L);
     }
+
+    @Test
+    void reportsPressure() {
+        queue.enqueue(1L);
+        assertThat(queue.pressure()).isEqualTo(0.5);
+        assertThat(queue.capacity()).isEqualTo(2);
+    }
+
+    @Test
+    void allowsEnqueueAfterQueueSlotFreed() throws Exception {
+        assertThat(queue.enqueue(1L)).isTrue();
+        assertThat(queue.enqueue(2L)).isTrue();
+        assertThat(queue.enqueue(3L)).isFalse();
+        queue.poll(100);
+        assertThat(queue.enqueue(3L)).isTrue();
+    }
 }

--- a/order-service/src/test/java/com/kholodilin/outbox/queue/InMemoryEventQueueTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/queue/InMemoryEventQueueTest.java
@@ -1,6 +1,8 @@
 package com.kholodilin.outbox.queue;
 
 import com.kholodilin.outbox.config.AppProperties;
+import com.kholodilin.outbox.config.MemoryQueueProperties;
+import com.kholodilin.outbox.config.OutboxProperties;
 import com.kholodilin.outbox.metrics.OutboxMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,10 +19,15 @@ class InMemoryEventQueueTest {
 
     @BeforeEach
     void setUp() {
-        AppProperties properties = new AppProperties();
-        properties.getOutbox().getMemoryQueue().setCapacity(2);
-        properties.getOutbox().getMemoryQueue().setBatchSize(10);
-        properties.getOutbox().getMemoryQueue().setBatchWait(Duration.ofMillis(10));
+        AppProperties properties = AppProperties.builder()
+                .outbox(OutboxProperties.builder()
+                        .memoryQueue(MemoryQueueProperties.builder()
+                                .capacity(2)
+                                .batchSize(10)
+                                .batchWait(Duration.ofMillis(10))
+                                .build())
+                        .build())
+                .build();
         queue = new InMemoryEventQueue(properties, new OutboxMetrics(new SimpleMeterRegistry()));
     }
 

--- a/outbox-events-contract/pom.xml
+++ b/outbox-events-contract/pom.xml
@@ -27,6 +27,16 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/CreateOrderRequest.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/CreateOrderRequest.java
@@ -20,12 +20,15 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CreateOrderRequest {
 
+    /** Customer who places the order; also used as the Kafka partition key. */
     @NotNull
     @Positive
     private Long customerId;
 
+    /** Line items that make up the order; must contain at least one element. */
     @NotEmpty
     private List<@Valid OrderItemRequest> items;
 
+    /** Optional trace id propagated to logs, outbox payload, and Kafka headers. */
     private String correlationId;
 }

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/CreateOrderResponse.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/CreateOrderResponse.java
@@ -16,8 +16,15 @@ import java.time.Instant;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CreateOrderResponse {
 
+    /** Identifier of the persisted order row. */
     private Long orderId;
+
+    /** Identifier of the outbox event scheduled for Kafka publish. */
     private Long eventId;
+
+    /** Business status of the accepted order (for example {@code ACCEPTED}). */
     private String status;
+
+    /** UTC timestamp when the order was stored. */
     private Instant createdAt;
 }

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventConstants.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventConstants.java
@@ -8,16 +8,31 @@ package com.kholodilin.outbox.events;
  */
 public final class EventConstants {
 
+    /** Kafka topic that carries order domain events. */
     public static final String TOPIC_ORDERS = "orders.events";
+
+    /** Event type emitted when a new order is accepted. */
     public static final String EVENT_TYPE_ORDER_CREATED = "OrderCreated";
+
     /** Kafka record key field — all events for one customer land in the same partition. */
     public static final String PARTITION_KEY_FIELD = "customerId";
+
+    /** Kafka / tracing header with the outbox event id. */
     public static final String HEADER_EVENT_ID = "eventId";
+
+    /** Kafka / tracing header with the business order id. */
     public static final String HEADER_ORDER_ID = "orderId";
+
+    /** Kafka / tracing header with the customer id. */
     public static final String HEADER_CUSTOMER_ID = "customerId";
+
+    /** Kafka / tracing header with the client-supplied correlation id. */
     public static final String HEADER_CORRELATION_ID = "correlationId";
+
+    /** HTTP header name for idempotent order creation requests. */
     public static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
 
+    /** Prevents instantiation of this constants holder. */
     private EventConstants() {
     }
 }

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventEnvelope.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventEnvelope.java
@@ -19,11 +19,24 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class EventEnvelope {
 
+    /** Primary key of the corresponding {@code outbox_events} row. */
     private Long eventId;
+
+    /** Identifier of the business order that triggered this event. */
     private Long orderId;
+
+    /** Customer identifier; serialized as the Kafka record key for partition ordering. */
     private Long customerId;
+
+    /** Domain event name (for example {@link EventConstants#EVENT_TYPE_ORDER_CREATED}). */
     private String eventType;
+
+    /** Event-specific JSON payload (structure depends on {@link #eventType}). */
     private Map<String, Object> payload;
+
+    /** Optional trace id copied from the originating HTTP request. */
     private String correlationId;
+
+    /** UTC timestamp when the envelope was assembled for publishing. */
     private Instant occurredAt;
 }

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/IdempotencyStatus.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/IdempotencyStatus.java
@@ -6,8 +6,14 @@ package com.kholodilin.outbox.events;
  * Persisted as {@code INT} in PostgreSQL ({@code status} column).
  */
 public enum IdempotencyStatus {
+
+    /** Request accepted; order transaction is in progress. */
     PROCESSING(0),
+
+    /** Order persisted and response body is available for replay. */
     COMPLETED(1),
+
+    /** Processing failed; the idempotency slot may be retried or cleaned up. */
     FAILED(2);
 
     private final int code;
@@ -16,10 +22,18 @@ public enum IdempotencyStatus {
         this.code = code;
     }
 
+    /** Returns the integer value stored in {@code idempotency_keys.status}. */
     public int getCode() {
         return code;
     }
 
+    /**
+     * Resolves an enum constant from its persisted integer code.
+     *
+     * @param code value read from {@code idempotency_keys.status}
+     * @return matching status
+     * @throws IllegalArgumentException when {@code code} is not recognized
+     */
     public static IdempotencyStatus fromCode(int code) {
         for (IdempotencyStatus status : values()) {
             if (status.code == code) {

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/OrderItemRequest.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/OrderItemRequest.java
@@ -19,12 +19,15 @@ import java.math.BigDecimal;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OrderItemRequest {
 
+    /** Stock-keeping unit or product identifier in the catalog. */
     @NotBlank
     private String productId;
 
+    /** Number of units ordered; must be greater than zero. */
     @Positive
     private int quantity;
 
+    /** Unit price at order time; must be positive. */
     @NotNull
     @Positive
     private BigDecimal price;

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/OutboxStatus.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/OutboxStatus.java
@@ -7,14 +7,23 @@ package com.kholodilin.outbox.events;
  * Values {@code < 100} are active (hot-path); {@code >= 100} are archived finals.
  */
 public enum OutboxStatus {
+
+    /** Inserted with the business transaction; waiting for the publisher. */
     NEW(0),
+
+    /** Claimed by a publisher worker under a lease; publish in progress. */
     PROCESSING(1),
+
+    /** Publish failed but may be retried or recovered. */
     FAILED(2),
+
     /** Max retries exceeded; manual intervention required. */
     DEAD(101),
+
     /** Published successfully; row moves to the archive partition. */
     SENT(110);
 
+    /** Status codes at or above this value belong to the archive partition. */
     public static final int ARCHIVE_THRESHOLD = 100;
 
     private final int code;
@@ -23,18 +32,28 @@ public enum OutboxStatus {
         this.code = code;
     }
 
+    /** Returns the integer value stored in {@code outbox_events.status}. */
     public int getCode() {
         return code;
     }
 
+    /** {@code true} when the row is in the active partition ({@code status < 100}). */
     public boolean isActive() {
         return code < ARCHIVE_THRESHOLD;
     }
 
+    /** {@code true} when the row is in the archive partition ({@code status >= 100}). */
     public boolean isArchive() {
         return code >= ARCHIVE_THRESHOLD;
     }
 
+    /**
+     * Resolves an enum constant from its persisted integer code.
+     *
+     * @param code value read from {@code outbox_events.status}
+     * @return matching status
+     * @throws IllegalArgumentException when {@code code} is not recognized
+     */
     public static OutboxStatus fromCode(int code) {
         for (OutboxStatus status : values()) {
             if (status.code == code) {

--- a/outbox-events-contract/src/test/java/com/kholodilin/outbox/events/OutboxStatusTest.java
+++ b/outbox-events-contract/src/test/java/com/kholodilin/outbox/events/OutboxStatusTest.java
@@ -1,0 +1,31 @@
+package com.kholodilin.outbox.events;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OutboxStatusTest {
+
+    @Test
+    void activeStatusesAreBelowArchiveThreshold() {
+        assertThat(OutboxStatus.NEW.isActive()).isTrue();
+        assertThat(OutboxStatus.PROCESSING.isActive()).isTrue();
+        assertThat(OutboxStatus.FAILED.isActive()).isTrue();
+        assertThat(OutboxStatus.DEAD.isArchive()).isTrue();
+        assertThat(OutboxStatus.SENT.isArchive()).isTrue();
+    }
+
+    @Test
+    void mapsKnownCodes() {
+        assertThat(OutboxStatus.fromCode(0)).isEqualTo(OutboxStatus.NEW);
+        assertThat(OutboxStatus.fromCode(110)).isEqualTo(OutboxStatus.SENT);
+    }
+
+    @Test
+    void rejectsUnknownCode() {
+        assertThatThrownBy(() -> OutboxStatus.fromCode(999))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("999");
+    }
+}


### PR DESCRIPTION
## Summary

Add Prometheus and Grafana to the local Docker Compose stack, provision an Outbox observability dashboard, and expose Prometheus metrics from `notification-stub`.

Closes #8
Closes #9
Closes #10

### Changes

- **Docker Compose**: `prometheus` (:9090) and `grafana` (:3000) services
- **Prometheus**: scrape `order-service` and `notification-stub` on host via `host.docker.internal`
- **Grafana**: auto-provisioned Prometheus datasource + **Transactional Outbox** dashboard
- **notification-stub**: `micrometer-registry-prometheus`, `/actuator/prometheus` endpoint
- **Docs**: Observability section in README and CONTRIBUTING

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Affected modules

- [ ] `outbox-events-contract`
- [ ] `order-service`
- [x] `notification-stub`
- [x] `docker-compose` / infrastructure
- [x] docs / CI / other

## Test plan

- [x] `docker compose config` validates compose file
- [x] `mvn -pl notification-stub -am package -DskipTests` — BUILD SUCCESS
- [ ] `docker compose up -d` + run services + verify targets UP (requires Docker image pull)

**Manual steps:**

```bash
docker compose up -d
mvn -pl order-service spring-boot:run -Dspring-boot.run.profiles=dev
mvn -pl notification-stub spring-boot:run -Dspring-boot.run.profiles=dev
curl -s http://localhost:8080/actuator/prometheus | head
curl -s http://localhost:8081/actuator/prometheus | head
# Prometheus targets: http://localhost:9090/targets
# Grafana dashboard: http://localhost:3000 (admin/admin)
```

## Checklist

- [x] Code follows existing project conventions
- [ ] Tests added or updated where appropriate
- [x] Documentation updated (if user-facing behavior changed)
- [x] No secrets or environment-specific credentials committed
- [ ] Liquibase/schema changes documented (if applicable)