### PR TITLE
Transactional Outbox Pattern - Distributed Tracing with OpenTelemetry and Grafana Tempo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,23 @@ mvn -pl notification-stub spring-boot:run -Dspring-boot.run.profiles=dev
 
 Metrics: Prometheus http://localhost:9090, Grafana http://localhost:3000 — see [README Observability](README.md#observability).
 
+### Distributed tracing (local)
+
+1. `docker compose up -d` — starts Tempo (OTLP HTTP `:4318`, query `:3200`).
+2. Run services with profile `dev` (100% sampling, OTLP to `localhost:4318`).
+3. Open Grafana → **Distributed Tracing** dashboard after creating an order.
+4. Logs include `traceId` and `spanId` via `logback-spring.xml`.
+
+Environment variables:
+
+| Variable | Default (dev) | Purpose |
+|----------|---------------|---------|
+| `TRACING_ENABLED` | `true` | Kill switch (`false` disables export) |
+| `TRACING_SAMPLING` | `1.0` / `0.1` prod | Trace sampling probability |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318/v1/traces` | Tempo OTLP HTTP endpoint |
+
+Integration tests run with `management.tracing.enabled=false` — no Tempo required in CI.
+
 ### Code coverage (JaCoCo)
 
 After `mvn clean verify`, JaCoCo XML reports are written per module:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Environment variables:
 |----------|---------------|---------|
 | `TRACING_ENABLED` | `true` | Kill switch (`false` disables export) |
 | `TRACING_SAMPLING` | `1.0` / `0.1` prod | Trace sampling probability |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318/v1/traces` | Tempo OTLP HTTP endpoint |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318/v1/traces` | Tempo OTLP HTTP traces endpoint (maps to `management.opentelemetry.tracing.export.otlp.endpoint`) |
 
 Integration tests run with `management.tracing.enabled=false` — no Tempo required in CI.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Kafka messages use **partition key = `customerId`**.
 
 ## Observability
 
-The local stack includes **Prometheus** and **Grafana** (via Docker Compose). Applications run on the host and expose metrics through Spring Boot Actuator.
+The local stack includes **Prometheus**, **Grafana**, and **Grafana Tempo** (via Docker Compose). Applications run on the host and export metrics through Actuator and traces through OTLP.
 
 ### 1. Start infrastructure (including monitoring)
 
@@ -89,6 +89,7 @@ docker compose up -d
 |---------|-----|-------|
 | Prometheus | http://localhost:9090 | scrapes apps on host + `postgres-exporter` |
 | Grafana | http://localhost:3000 | login `admin` / `admin` (dev only) |
+| Grafana Tempo | http://localhost:3200 | OTLP HTTP ingest on `:4318` |
 | postgres-exporter | http://localhost:9187/metrics | standard PostgreSQL metrics |
 
 ### 2. Run services and generate traffic
@@ -105,7 +106,26 @@ curl -s http://localhost:8080/actuator/prometheus | head
 curl -s http://localhost:8081/actuator/prometheus | head
 ```
 
-Create an order (see API example above), then open Grafana — dashboards **Transactional Outbox**, **Notification Stub**, and **PostgreSQL** are provisioned automatically.
+Create an order (see API example above), then open Grafana — dashboards **Transactional Outbox**, **Notification Stub**, **PostgreSQL**, and **Distributed Tracing** are provisioned automatically.
+
+### Distributed tracing (Tempo)
+
+With `dev` profile, both services export traces to `http://localhost:4318/v1/traces` (100% sampling).
+
+1. Start `docker compose up -d` (includes Tempo).
+2. Run `order-service` and `notification-stub` with profile `dev`.
+3. `POST /api/v1/orders` (see API example).
+4. Grafana → **Distributed Tracing** dashboard → browse recent traces or paste a `traceId` from logs (`traceId=...` in logback output).
+
+End-to-end trace path: HTTP → outbox save → batch publish → Kafka consumer.
+
+Disable tracing without code changes:
+
+```bash
+TRACING_ENABLED=false mvn -pl order-service spring-boot:run -Dspring-boot.run.profiles=dev
+```
+
+Production sampling defaults to `10%` (`TRACING_SAMPLING=0.1` in `application-prod.yml`).
 
 Prometheus targets: http://localhost:9090/targets (`order-service`, `notification-stub`, `postgres` should be **UP** while the stack is running).
 
@@ -135,3 +155,4 @@ Prometheus targets: http://localhost:9090/targets (`order-service`, `notificatio
 
 - [Technical Specification v2](docs/spring-transactional-outbox-kafka-Technical-Specification-v2.md)
 - [Implementation Plan](docs/spring-transactional-outbox-kafka-Implementation-Plan.md)
+- [Distributed Tracing Spec](docs/spring-transactional-outbox-kafka-Distributed-Tracing-Spec.md)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# spring-transactional-outbox-kafka
+# Transactional Outbox Pattern with Kafka and PostgreSQL
 
 [![CI](https://github.com/KHolodilin/spring-transactional-outbox-kafka/actions/workflows/ci.yml/badge.svg)](https://github.com/KHolodilin/spring-transactional-outbox-kafka/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/KHolodilin/spring-transactional-outbox-kafka/graph/badge.svg)](https://codecov.io/gh/KHolodilin/spring-transactional-outbox-kafka)
@@ -110,7 +110,7 @@ Create an order (see API example above), then open Grafana — dashboards **Tran
 
 ### Distributed tracing (Tempo)
 
-With `dev` profile, both services export traces to `http://localhost:4318/v1/traces` (100% sampling).
+With `dev` profile, both services export traces via Spring Boot 4 OTLP config (`management.opentelemetry.tracing.export.otlp.endpoint`, default `http://localhost:4318/v1/traces`, 100% sampling).
 
 1. Start `docker compose up -d` (includes Tempo).
 2. Run `order-service` and `notification-stub` with profile `dev`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - "--storage.tsdb.path=/prometheus"
 
   grafana:
-    image: grafana/grafana:12.0.2
+    image: grafana/grafana:12.3.3
     ports:
       - "3000:3000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,3 +65,13 @@ services:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
+      - tempo
+
+  tempo:
+    image: grafana/tempo:2.7.2
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    ports:
+      - "3200:3200"
+      - "4318:4318"
+    volumes:
+      - ./monitoring/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       retries: 10
 
   postgres-exporter:
-    image: prometheuscommunity/postgres-exporter:v0.16.0
+    image: prometheuscommunity/postgres-exporter:v0.17.1
     environment:
       DATA_SOURCE_NAME: "postgresql://outbox:outbox@postgres:5432/outbox?sslmode=disable"
     ports:
@@ -24,7 +24,7 @@ services:
         condition: service_healthy
 
   kafka:
-    image: apache/kafka:3.8.1
+    image: apache/kafka:3.9.1
     ports:
       - "9092:9092"
     environment:
@@ -42,7 +42,7 @@ services:
       CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
 
   prometheus:
-    image: prom/prometheus:v3.2.1
+    image: prom/prometheus:v3.5.0
     ports:
       - "9090:9090"
     extra_hosts:
@@ -54,7 +54,7 @@ services:
       - "--storage.tsdb.path=/prometheus"
 
   grafana:
-    image: grafana/grafana:11.6.0
+    image: grafana/grafana:12.0.2
     ports:
       - "3000:3000"
     environment:
@@ -68,7 +68,7 @@ services:
       - tempo
 
   tempo:
-    image: grafana/tempo:2.7.2
+    image: grafana/tempo:2.8.0
     command: ["-config.file=/etc/tempo/tempo.yaml"]
     ports:
       - "3200:3200"

--- a/docs/spring-transactional-outbox-kafka-Distributed-Tracing-Spec.md
+++ b/docs/spring-transactional-outbox-kafka-Distributed-Tracing-Spec.md
@@ -1,0 +1,327 @@
+# Technical Specification
+# Distributed Tracing for spring-transactional-outbox-kafka
+
+## 1. Goal
+
+Implement production-ready distributed tracing for the Transactional Outbox workflow.
+
+The tracing must allow developers to follow an event from the incoming HTTP request through database persistence, Outbox, Kafka publishing and Kafka consumer processing.
+
+The solution must integrate with Grafana Tempo using OpenTelemetry.
+
+---
+
+# 2. Technology Stack
+
+## Application
+- Spring Boot 4
+- Micrometer Tracing
+- OpenTelemetry
+
+## Transport
+- OTLP (OpenTelemetry Protocol)
+
+## Storage
+- Grafana Tempo
+
+## Visualization
+- Grafana
+
+OpenTelemetry Collector is **not required** in the first version.
+
+---
+
+# 3. High-Level Architecture
+
+```text
+HTTP Request
+    │
+    ▼
+Order Service
+    │
+    ├── Business Logic
+    ├── PostgreSQL
+    ├── Outbox
+    │
+    ▼
+Outbox Publisher
+    │
+    ▼
+Kafka Producer
+    │
+    ▼
+Kafka Topic
+    │
+    ▼
+Kafka Consumer
+    │
+    ▼
+Business Processing
+```
+
+All operations should belong to the same distributed trace whenever possible.
+
+---
+
+# 4. HTTP Tracing
+
+Every incoming HTTP request automatically creates a root trace.
+
+Captured information:
+
+- HTTP method
+- URI
+- Status code
+- Duration
+- Service name
+
+HTTP request/response bodies must not be exported.
+
+---
+
+# 5. Database Tracing
+
+Database operations should appear as child spans.
+
+Example:
+
+```text
+INSERT orders
+INSERT outbox
+SELECT outbox batch
+UPDATE outbox status
+```
+
+SQL parameters must never be exported.
+
+---
+
+# 6. Outbox Tracing
+
+Create dedicated spans:
+
+```text
+outbox.save
+outbox.batch.fetch
+outbox.publish
+outbox.mark.sent
+outbox.retry
+outbox.archive
+```
+
+Recommended attributes:
+
+```text
+outbox.event.type
+outbox.batch.size
+outbox.status
+outbox.retry.count
+```
+
+Never export event payloads.
+
+---
+
+# 7. Trace Context Persistence
+
+To preserve distributed tracing across asynchronous publishing, store the trace context together with every Outbox record.
+
+Recommended database column:
+
+```text
+trace_parent
+```
+
+instead of only:
+
+```text
+trace_id
+```
+
+Store the full W3C Trace Context.
+
+Example:
+
+```text
+00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+```
+
+---
+
+# 8. Kafka Producer
+
+Before publishing an event:
+
+- Restore tracing context from the Outbox record.
+- Continue the original trace.
+- Propagate tracing through Kafka headers.
+
+Required headers:
+
+```text
+traceparent
+tracestate (optional)
+```
+
+---
+
+# 9. Kafka Consumer
+
+The consumer automatically continues the trace received from Kafka.
+
+Expected trace:
+
+```text
+HTTP Request
+├── Save Order
+├── Save Outbox
+├── Kafka Publish
+└── Kafka Consumer
+    ├── Deserialize
+    ├── Business Logic
+    └── Complete
+```
+
+---
+
+# 10. Scheduled Publisher
+
+Scheduled publisher should create spans:
+
+```text
+batch.fetch
+batch.publish
+batch.complete
+```
+
+If `traceparent` exists inside the Outbox record, continue the original trace instead of creating a new one.
+
+---
+
+# 11. Logging Integration
+
+Every log record should contain:
+
+```text
+traceId
+spanId
+```
+
+Example:
+
+```text
+INFO traceId=4bf92f... spanId=1ac245...
+Published batch size=100
+```
+
+---
+
+# 12. Tempo Export
+
+```text
+Spring Boot
+      │
+      ▼
+    OTLP
+      │
+      ▼
+ Grafana Tempo
+      │
+      ▼
+   Grafana
+```
+
+Example configuration:
+
+```yaml
+management:
+  tracing:
+    enabled: true
+    sampling:
+      probability: 1.0
+
+  otlp:
+    tracing:
+      endpoint: http://tempo:4318/v1/traces
+```
+
+---
+
+# 13. Sampling
+
+Development:
+
+```text
+100%
+```
+
+Production:
+
+```text
+Configurable (recommended 10%)
+```
+
+---
+
+# 14. Security
+
+Never export:
+
+- HTTP bodies
+- Kafka payloads
+- SQL parameters
+- Passwords
+- Tokens
+- Secrets
+- Personal information
+
+---
+
+# 15. Docker Compose
+
+```text
+application
+postgres
+kafka
+prometheus
+grafana
+tempo
+```
+
+OpenTelemetry Collector is intentionally omitted in v1.
+
+---
+
+# 16. Acceptance Criteria
+
+- HTTP requests create traces.
+- Database operations appear as spans.
+- Outbox operations are visible.
+- Kafka Producer is traced.
+- Kafka Consumer continues the same trace.
+- Trace context is propagated through Kafka headers.
+- Outbox stores `traceparent`.
+- Logs contain `traceId` and `spanId`.
+- Grafana displays the complete end-to-end trace.
+- Tracing can be disabled without affecting application behavior.
+
+---
+
+# 17. Expected End-to-End Trace
+
+```text
+HTTP POST /orders
+│
+├── Controller
+├── Validation
+├── Save Order
+├── Save Outbox
+├── Commit Transaction
+├── Outbox Publisher
+├── Kafka Producer
+├── Kafka Broker
+├── Kafka Consumer
+├── Deserialize
+├── Business Processing
+└── Acknowledge Message
+```

--- a/monitoring/grafana/provisioning/dashboards/outbox-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/outbox-dashboard.json
@@ -18,6 +18,12 @@
       "type": "link",
       "url": "/d/postgresql/postgresql",
       "icon": "external link"
+    },
+    {
+      "title": "Distributed Tracing",
+      "type": "link",
+      "url": "/d/distributed-tracing/distributed-tracing",
+      "icon": "external link"
     }
   ],
   "panels": [

--- a/monitoring/grafana/provisioning/dashboards/tracing-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/tracing-dashboard.json
@@ -1,0 +1,250 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "title": "Transactional Outbox",
+      "type": "link",
+      "url": "/d/transactional-outbox/transactional-outbox",
+      "icon": "external link"
+    },
+    {
+      "title": "Notification Stub",
+      "type": "link",
+      "url": "/d/notification-stub/notification-stub",
+      "icon": "external link"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "queryType": "traceqlSearch",
+          "query": "{resource.service.name=~\"$service\" && name=~\"$span\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Trace Search",
+      "type": "traces"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "queryType": "traceql",
+          "query": "{resource.service.name=\"order-service\" && name=\"http.server.requests\" && span.http.route=\"/api/v1/orders\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP POST /api/v1/orders",
+      "type": "traces"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 3,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "queryType": "traceql",
+          "query": "{name=~\"outbox.*\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbox Pipeline Spans",
+      "type": "traces"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 4,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "queryType": "traceql",
+          "query": "{resource.service.name=\"notification-stub\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Kafka Consumer (notification-stub)",
+      "type": "traces"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 5,
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "query": "$trace_id",
+          "queryType": "traceId",
+          "refId": "A"
+        }
+      ],
+      "title": "Trace Drill-down",
+      "type": "traces"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "tracing",
+    "tempo",
+    "outbox"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "order-service",
+          "value": "order-service"
+        },
+        "includeAll": true,
+        "label": "Service",
+        "multi": false,
+        "name": "service",
+        "options": [
+          {
+            "selected": true,
+            "text": "order-service",
+            "value": "order-service"
+          },
+          {
+            "selected": false,
+            "text": "notification-stub",
+            "value": "notification-stub"
+          }
+        ],
+        "query": "order-service,notification-stub",
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": ".*"
+        },
+        "includeAll": true,
+        "label": "Span",
+        "name": "span",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": ".*"
+          },
+          {
+            "selected": false,
+            "text": "outbox.save",
+            "value": "outbox.save"
+          },
+          {
+            "selected": false,
+            "text": "outbox.publish",
+            "value": "outbox.publish"
+          },
+          {
+            "selected": false,
+            "text": "http.server.requests",
+            "value": "http.server.requests"
+          }
+        ],
+        "query": ".*,outbox.save,outbox.batch.fetch,outbox.publish,outbox.mark.sent,outbox.recovery,http.server.requests",
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "label": "Trace ID",
+        "name": "trace_id",
+        "options": [],
+        "query": "",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Distributed Tracing",
+  "uid": "distributed-tracing",
+  "version": 1
+}

--- a/monitoring/grafana/provisioning/dashboards/tracing-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/tracing-dashboard.json
@@ -161,7 +161,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 18
       },
@@ -192,33 +192,6 @@
       ],
       "title": "Kafka Consumer (notification-stub)",
       "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "tempo",
-        "uid": "tempo"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 18
-      },
-      "id": 5,
-      "options": {},
-      "targets": [
-        {
-          "datasource": {
-            "type": "tempo",
-            "uid": "tempo"
-          },
-          "query": "${trace_id}",
-          "queryType": "traceId",
-          "refId": "A"
-        }
-      ],
-      "title": "Trace Drill-down (paste Trace ID above)",
-      "type": "traces"
     }
   ],
   "refresh": "10s",
@@ -295,17 +268,6 @@
         ],
         "query": ".*,outbox.save,outbox.batch.fetch,outbox.batch.publish,outbox.publish,outbox.mark.sent,outbox.recovery,http post /api/v1/orders,notification.batch.receive,notification.consume",
         "type": "custom"
-      },
-      {
-        "current": {
-          "text": "",
-          "value": ""
-        },
-        "label": "Trace ID",
-        "name": "trace_id",
-        "options": [],
-        "query": "",
-        "type": "textbox"
       }
     ]
   },
@@ -317,5 +279,5 @@
   "timezone": "browser",
   "title": "Distributed Tracing",
   "uid": "distributed-tracing",
-  "version": 4
+  "version": 5
 }

--- a/monitoring/grafana/provisioning/dashboards/tracing-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/tracing-dashboard.json
@@ -68,7 +68,7 @@
             "uid": "tempo"
           },
           "queryType": "traceql",
-          "query": "{resource.service.name=\"order-service\" && name=\"http.server.requests\" && span.http.route=\"/api/v1/orders\"}",
+          "query": "{resource.service.name=\"order-service\" && name=\"http post /api/v1/orders\"}",
           "refId": "A"
         }
       ],
@@ -122,7 +122,7 @@
             "uid": "tempo"
           },
           "queryType": "traceql",
-          "query": "{resource.service.name=\"notification-stub\"}",
+          "query": "{resource.service.name=\"notification-stub\" && name=~\"notification.*\"}",
           "refId": "A"
         }
       ],
@@ -218,11 +218,16 @@
           },
           {
             "selected": false,
-            "text": "http.server.requests",
-            "value": "http.server.requests"
+            "text": "http post /api/v1/orders",
+            "value": "http post /api/v1/orders"
+          },
+          {
+            "selected": false,
+            "text": "notification.consume",
+            "value": "notification.consume"
           }
         ],
-        "query": ".*,outbox.save,outbox.batch.fetch,outbox.publish,outbox.mark.sent,outbox.recovery,http.server.requests",
+        "query": ".*,outbox.save,outbox.batch.fetch,outbox.batch.publish,outbox.publish,outbox.mark.sent,outbox.recovery,http post /api/v1/orders,notification.batch.receive,notification.consume",
         "type": "custom"
       },
       {

--- a/monitoring/grafana/provisioning/dashboards/tracing-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/tracing-dashboard.json
@@ -75,7 +75,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 10
       },
@@ -105,49 +105,6 @@
         }
       ],
       "title": "HTTP POST /api/v1/orders",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "tempo",
-        "uid": "tempo"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 10
-      },
-      "id": 3,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": ["sum"],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "tempo",
-            "uid": "tempo"
-          },
-          "filters": [],
-          "limit": 20,
-          "query": "{ name =~ \"outbox.*\" }",
-          "queryType": "traceql",
-          "refId": "A",
-          "tableType": "traces"
-        }
-      ],
-      "title": "Outbox Pipeline Spans",
       "type": "table"
     },
     {
@@ -191,6 +148,49 @@
         }
       ],
       "title": "Kafka Consumer (notification-stub)",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "filters": [],
+          "limit": 20,
+          "query": "{ name =~ \"outbox.*\" }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "Outbox Pipeline Spans",
       "type": "table"
     }
   ],
@@ -279,5 +279,5 @@
   "timezone": "browser",
   "title": "Distributed Tracing",
   "uid": "distributed-tracing",
-  "version": 5
+  "version": 7
 }

--- a/monitoring/grafana/provisioning/dashboards/tracing-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/tracing-dashboard.json
@@ -26,6 +26,10 @@
         "type": "tempo",
         "uid": "tempo"
       },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 10,
         "w": 24,
@@ -33,25 +37,41 @@
         "y": 0
       },
       "id": 1,
-      "options": {},
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
       "targets": [
         {
           "datasource": {
             "type": "tempo",
             "uid": "tempo"
           },
-          "queryType": "traceqlSearch",
-          "query": "{resource.service.name=~\"$service\" && name=~\"$span\"}",
-          "refId": "A"
+          "filters": [],
+          "limit": 30,
+          "query": "{ resource.service.name = \"${service}\" }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
         }
       ],
       "title": "Trace Search",
-      "type": "traces"
+      "type": "table"
     },
     {
       "datasource": {
         "type": "tempo",
         "uid": "tempo"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -60,25 +80,41 @@
         "y": 10
       },
       "id": 2,
-      "options": {},
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
       "targets": [
         {
           "datasource": {
             "type": "tempo",
             "uid": "tempo"
           },
+          "filters": [],
+          "limit": 20,
+          "query": "{ resource.service.name = \"order-service\" && name = \"http post /api/v1/orders\" }",
           "queryType": "traceql",
-          "query": "{resource.service.name=\"order-service\" && name=\"http post /api/v1/orders\"}",
-          "refId": "A"
+          "refId": "A",
+          "tableType": "traces"
         }
       ],
       "title": "HTTP POST /api/v1/orders",
-      "type": "traces"
+      "type": "table"
     },
     {
       "datasource": {
         "type": "tempo",
         "uid": "tempo"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -87,25 +123,41 @@
         "y": 10
       },
       "id": 3,
-      "options": {},
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
       "targets": [
         {
           "datasource": {
             "type": "tempo",
             "uid": "tempo"
           },
+          "filters": [],
+          "limit": 20,
+          "query": "{ name =~ \"outbox.*\" }",
           "queryType": "traceql",
-          "query": "{name=~\"outbox.*\"}",
-          "refId": "A"
+          "refId": "A",
+          "tableType": "traces"
         }
       ],
       "title": "Outbox Pipeline Spans",
-      "type": "traces"
+      "type": "table"
     },
     {
       "datasource": {
         "type": "tempo",
         "uid": "tempo"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -114,20 +166,32 @@
         "y": 18
       },
       "id": 4,
-      "options": {},
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
       "targets": [
         {
           "datasource": {
             "type": "tempo",
             "uid": "tempo"
           },
+          "filters": [],
+          "limit": 20,
+          "query": "{ resource.service.name = \"notification-stub\" && name =~ \"notification.*\" }",
           "queryType": "traceql",
-          "query": "{resource.service.name=\"notification-stub\" && name=~\"notification.*\"}",
-          "refId": "A"
+          "refId": "A",
+          "tableType": "traces"
         }
       ],
       "title": "Kafka Consumer (notification-stub)",
-      "type": "traces"
+      "type": "table"
     },
     {
       "datasource": {
@@ -148,12 +212,12 @@
             "type": "tempo",
             "uid": "tempo"
           },
-          "query": "$trace_id",
+          "query": "${trace_id}",
           "queryType": "traceId",
           "refId": "A"
         }
       ],
-      "title": "Trace Drill-down",
+      "title": "Trace Drill-down (paste Trace ID above)",
       "type": "traces"
     }
   ],
@@ -167,6 +231,7 @@
   "templating": {
     "list": [
       {
+        "allValue": ".*",
         "current": {
           "selected": true,
           "text": "order-service",
@@ -192,6 +257,7 @@
         "type": "custom"
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": true,
           "text": "All",
@@ -251,5 +317,5 @@
   "timezone": "browser",
   "title": "Distributed Tracing",
   "uid": "distributed-tracing",
-  "version": 1
+  "version": 4
 }

--- a/monitoring/grafana/provisioning/datasources/tempo.yml
+++ b/monitoring/grafana/provisioning/datasources/tempo.yml
@@ -13,3 +13,8 @@ datasources:
         datasourceUid: prometheus
       tracesToLogsV2:
         datasourceUid: prometheus
+      search:
+        hide: false
+      streamingEnabled:
+        search: false
+        metrics: false

--- a/monitoring/grafana/provisioning/datasources/tempo.yml
+++ b/monitoring/grafana/provisioning/datasources/tempo.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus
+      tracesToLogsV2:
+        datasourceUid: prometheus

--- a/monitoring/tempo/tempo.yaml
+++ b/monitoring/tempo/tempo.yaml
@@ -1,0 +1,44 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 168h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+
+querier: {}
+
+query_frontend:
+  search:
+    duration_slo: 5s
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /var/tempo/generator/wal
+  traces_storage:
+    path: /var/tempo/generator/traces
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics]

--- a/notification-stub/pom.xml
+++ b/notification-stub/pom.xml
@@ -35,12 +35,8 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-tracing-bridge-otel</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/notification-stub/pom.xml
+++ b/notification-stub/pom.xml
@@ -35,6 +35,14 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/notification-stub/src/main/java/com/kholodilin/outbox/notification/NotificationStubHandler.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/notification/NotificationStubHandler.java
@@ -1,18 +1,24 @@
 package com.kholodilin.outbox.notification;
 
+import com.kholodilin.outbox.events.EventConstants;
 import com.kholodilin.outbox.events.EventEnvelope;
 import com.kholodilin.outbox.metrics.NotificationStubMetrics;
+import com.kholodilin.outbox.tracing.TraceContextSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
  * Demo downstream consumer that pretends to send customer notifications.
  * <p>
  * No real email/SMS integration — logs only, to show the end-to-end outbox pipeline.
+ * Restores W3C trace context from Kafka {@code traceparent} headers.
  */
 @Slf4j
 @Component
@@ -20,21 +26,44 @@ import java.util.List;
 public class NotificationStubHandler {
 
     private final NotificationStubMetrics metrics;
+    private final TraceContextSupport traceContextSupport;
 
     @KafkaListener(
             topics = "${app.kafka.topic}",
             containerFactory = "batchKafkaListenerContainerFactory"
     )
-    public void handleBatch(List<EventEnvelope> events) {
-        metrics.recordBatch(events.size(), () -> {
-            log.info("Notification stub batch received size={}", events.size());
-            for (EventEnvelope event : events) {
-                log.info("Notification stub sent orderId={} customerId={} eventId={}",
-                        event.getOrderId(), event.getCustomerId(), event.getEventId());
-                log.debug("Notification stub event details eventType={} correlationId={} payload={}",
-                        event.getEventType(), event.getCorrelationId(), event.getPayload());
-            }
-            log.info("Notification stub batch processed size={}", events.size());
+    public void handleBatch(List<ConsumerRecord<String, EventEnvelope>> records) {
+        if (records.isEmpty()) {
+            return;
+        }
+        String batchTraceParent = extractTraceParent(records.get(0));
+        traceContextSupport.runWithTraceParent(batchTraceParent, "notification.batch.receive", () -> {
+            metrics.recordBatch(records.size(), () -> {
+                log.info("Notification stub batch received size={}", records.size());
+                for (ConsumerRecord<String, EventEnvelope> record : records) {
+                    traceContextSupport.runWithTraceParent(
+                            extractTraceParent(record),
+                            "notification.consume",
+                            () -> logEvent(record.value())
+                    );
+                }
+                log.info("Notification stub batch processed size={}", records.size());
+            });
         });
+    }
+
+    private void logEvent(EventEnvelope event) {
+        log.info("Notification stub sent orderId={} customerId={} eventId={}",
+                event.getOrderId(), event.getCustomerId(), event.getEventId());
+        log.debug("Notification stub event details eventType={} correlationId={} payload={}",
+                event.getEventType(), event.getCorrelationId(), event.getPayload());
+    }
+
+    private String extractTraceParent(ConsumerRecord<String, EventEnvelope> record) {
+        Header header = record.headers().lastHeader(EventConstants.HEADER_TRACEPARENT);
+        if (header == null || header.value() == null) {
+            return null;
+        }
+        return new String(header.value(), StandardCharsets.UTF_8);
     }
 }

--- a/notification-stub/src/main/java/com/kholodilin/outbox/tracing/ActuatorTracingExclusionConfig.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/tracing/ActuatorTracingExclusionConfig.java
@@ -1,31 +1,67 @@
 package com.kholodilin.outbox.tracing;
 
+import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationPredicate;
+import io.micrometer.observation.ObservationView;
+import io.micrometer.tracing.exporter.SpanExportingPredicate;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
+import org.springframework.util.AntPathMatcher;
 
 @Configuration
 public class ActuatorTracingExclusionConfig {
 
-    private final String actuatorBasePath;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private final String actuatorPattern;
 
     public ActuatorTracingExclusionConfig(
             @Value("${management.endpoints.web.base-path:/actuator}") String actuatorBasePath) {
-        this.actuatorBasePath = actuatorBasePath.endsWith("/")
+        String normalized = actuatorBasePath.endsWith("/")
                 ? actuatorBasePath.substring(0, actuatorBasePath.length() - 1)
                 : actuatorBasePath;
+        this.actuatorPattern = normalized + "/**";
     }
 
     @Bean
     ObservationPredicate noActuatorObservationPredicate() {
-        return (name, context) -> {
-            if (context instanceof ServerRequestObservationContext serverContext) {
-                String uri = serverContext.getCarrier().getRequestURI();
-                return uri == null || !uri.startsWith(actuatorBasePath);
-            }
-            return true;
+        return (name, context) -> !matchesActuator(name, context);
+    }
+
+    @Bean
+    SpanExportingPredicate noActuatorSpanExportingPredicate() {
+        return span -> {
+            String name = span.getName();
+            return name == null || !name.contains("/actuator");
         };
+    }
+
+    private boolean matchesActuator(String name, Observation.Context context) {
+        if (name != null && name.contains("/actuator")) {
+            return true;
+        }
+
+        Observation.Context current = context;
+        while (current != null) {
+            if (current instanceof ServerRequestObservationContext serverContext) {
+                Object carrier = serverContext.getCarrier();
+                if (carrier instanceof HttpServletRequest request) {
+                    String uri = request.getRequestURI();
+                    if (uri != null && pathMatcher.match(actuatorPattern, uri)) {
+                        return true;
+                    }
+                }
+            }
+
+            ObservationView parentObservation = current.getParentObservation();
+            if (parentObservation == null) {
+                break;
+            }
+            current = (Observation.Context) parentObservation.getContextView();
+        }
+
+        return false;
     }
 }

--- a/notification-stub/src/main/java/com/kholodilin/outbox/tracing/ActuatorTracingExclusionConfig.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/tracing/ActuatorTracingExclusionConfig.java
@@ -1,0 +1,31 @@
+package com.kholodilin.outbox.tracing;
+
+import io.micrometer.observation.ObservationPredicate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.observation.ServerRequestObservationContext;
+
+@Configuration
+public class ActuatorTracingExclusionConfig {
+
+    private final String actuatorBasePath;
+
+    public ActuatorTracingExclusionConfig(
+            @Value("${management.endpoints.web.base-path:/actuator}") String actuatorBasePath) {
+        this.actuatorBasePath = actuatorBasePath.endsWith("/")
+                ? actuatorBasePath.substring(0, actuatorBasePath.length() - 1)
+                : actuatorBasePath;
+    }
+
+    @Bean
+    ObservationPredicate noActuatorObservationPredicate() {
+        return (name, context) -> {
+            if (context instanceof ServerRequestObservationContext serverContext) {
+                String uri = serverContext.getCarrier().getRequestURI();
+                return uri == null || !uri.startsWith(actuatorBasePath);
+            }
+            return true;
+        };
+    }
+}

--- a/notification-stub/src/main/java/com/kholodilin/outbox/tracing/TraceContextSupport.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/tracing/TraceContextSupport.java
@@ -1,0 +1,58 @@
+package com.kholodilin.outbox.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Restores W3C trace context from Kafka headers for downstream consumption.
+ * No-ops when Micrometer tracing is disabled.
+ */
+@Component
+public class TraceContextSupport {
+
+    private static final String TRACE_PARENT_KEY = "traceparent";
+
+    private final ObjectProvider<Tracer> tracerProvider;
+    private final ObjectProvider<Propagator> propagatorProvider;
+
+    public TraceContextSupport(ObjectProvider<Tracer> tracerProvider, ObjectProvider<Propagator> propagatorProvider) {
+        this.tracerProvider = tracerProvider;
+        this.propagatorProvider = propagatorProvider;
+    }
+
+    public void runWithTraceParent(String traceParent, String spanName, Runnable action) {
+        runWithTraceParent(traceParent, spanName, () -> {
+            action.run();
+            return null;
+        });
+    }
+
+    public <T> T runWithTraceParent(String traceParent, String spanName, Supplier<T> action) {
+        Tracer tracer = tracerProvider.getIfAvailable();
+        Propagator propagator = propagatorProvider.getIfAvailable();
+        if (tracer == null || propagator == null) {
+            return action.get();
+        }
+        Span span = startSpan(tracer, propagator, traceParent, spanName);
+        try (Tracer.SpanInScope scope = tracer.withSpan(span)) {
+            return action.get();
+        } finally {
+            span.end();
+        }
+    }
+
+    private Span startSpan(Tracer tracer, Propagator propagator, String traceParent, String spanName) {
+        if (traceParent == null || traceParent.isBlank()) {
+            return tracer.nextSpan().name(spanName).start();
+        }
+        Map<String, String> carrier = Map.of(TRACE_PARENT_KEY, traceParent);
+        return propagator.extract(carrier, Map::get).name(spanName).start();
+    }
+}

--- a/notification-stub/src/main/resources/application-dev.yml
+++ b/notification-stub/src/main/resources/application-dev.yml
@@ -2,6 +2,14 @@ logging:
   level:
     com.kholodilin.outbox: DEBUG
 
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: http://localhost:4318/v1/traces
+
 spring:
   kafka:
     consumer:

--- a/notification-stub/src/main/resources/application-dev.yml
+++ b/notification-stub/src/main/resources/application-dev.yml
@@ -7,8 +7,15 @@ management:
     sampling:
       probability: 1.0
   otlp:
+    metrics:
+      export:
+        enabled: false
+  opentelemetry:
     tracing:
-      endpoint: http://localhost:4318/v1/traces
+      export:
+        otlp:
+          endpoint: http://localhost:4318/v1/traces
+          timeout: 2s
 
 spring:
   kafka:

--- a/notification-stub/src/main/resources/application-prod.yml
+++ b/notification-stub/src/main/resources/application-prod.yml
@@ -1,3 +1,8 @@
 logging:
   level:
     com.kholodilin.outbox: INFO
+
+management:
+  tracing:
+    sampling:
+      probability: ${TRACING_SAMPLING:0.1}

--- a/notification-stub/src/main/resources/application.yml
+++ b/notification-stub/src/main/resources/application.yml
@@ -26,9 +26,11 @@ management:
       probability: ${TRACING_SAMPLING:1.0}
     propagation:
       type: w3c
-  otlp:
+  opentelemetry:
     tracing:
-      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
+      export:
+        otlp:
+          endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
 
 logging:
   level:

--- a/notification-stub/src/main/resources/application.yml
+++ b/notification-stub/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     name: notification-stub
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP:localhost:9092}
+    listener:
+      observation-enabled: true
     consumer:
       group-id: notification-stub
       auto-offset-reset: earliest
@@ -18,6 +20,15 @@ management:
     web:
       exposure:
         include: health,metrics,prometheus
+  tracing:
+    enabled: ${TRACING_ENABLED:true}
+    sampling:
+      probability: ${TRACING_SAMPLING:1.0}
+    propagation:
+      type: w3c
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
 
 logging:
   level:

--- a/notification-stub/src/main/resources/logback-spring.xml
+++ b/notification-stub/src/main/resources/logback-spring.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <springProperty scope="context" name="appName" source="spring.application.name"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %5p ${PID:- } --- [%15.15t] %-40.40logger{39} : traceId=%X{traceId:-} spanId=%X{spanId:-} %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -68,6 +68,14 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -68,12 +68,8 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-tracing-bridge-otel</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/order-service/src/main/java/com/kholodilin/outbox/config/KafkaProducerConfig.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/KafkaProducerConfig.java
@@ -25,6 +25,9 @@ public class KafkaProducerConfig {
         Map<String, Object> config = new HashMap<>();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, environment.getProperty("spring.kafka.bootstrap-servers"));
         config.put(ProducerConfig.ACKS_CONFIG, environment.getProperty("spring.kafka.producer.acks", "all"));
+        config.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 10_000);
+        config.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30_000);
+        config.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 60_000);
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 
         JsonSerializer<Object> valueSerializer = new JsonSerializer<>(kafkaObjectMapper());

--- a/order-service/src/main/java/com/kholodilin/outbox/order/OrderTransactionService.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/order/OrderTransactionService.java
@@ -9,6 +9,7 @@ import com.kholodilin.outbox.outbox.OutboxEnqueueListener;
 import com.kholodilin.outbox.outbox.OutboxEventFactory;
 import com.kholodilin.outbox.persistence.OrderJdbcRepository;
 import com.kholodilin.outbox.persistence.OutboxJdbcRepository;
+import com.kholodilin.outbox.tracing.TraceContextSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,7 @@ public class OrderTransactionService {
     private final OutboxEventFactory outboxEventFactory;
     private final OutboxEnqueueListener outboxEnqueueListener;
     private final ObjectMapper objectMapper;
+    private final TraceContextSupport traceContextSupport;
 
     @Transactional
     public CreateOrderResponse createOrder(CreateOrderRequest request, String idempotencyKey, String requestHash) {
@@ -57,11 +59,13 @@ public class OrderTransactionService {
         }
 
         String payload = outboxEventFactory.buildOrderCreatedPayload(orderId, request);
+        String traceParent = traceContextSupport.captureTraceParent();
         long eventId = outboxJdbcRepository.insertEvent(
                 orderId,
                 request.getCustomerId(),
                 outboxEventFactory.eventType(),
                 payload,
+                traceParent,
                 now
         );
 

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxJdbcRepository.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxJdbcRepository.java
@@ -3,6 +3,7 @@ package com.kholodilin.outbox.persistence;
 import tools.jackson.databind.ObjectMapper;
 import com.kholodilin.outbox.events.EventEnvelope;
 import com.kholodilin.outbox.events.OutboxStatus;
+import com.kholodilin.outbox.tracing.OutboxTracing;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -27,6 +28,9 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class OutboxJdbcRepository {
 
+    private static final String OUTBOX_ROW_COLUMNS =
+            "id, order_id, customer_id, event_type, payload::text AS payload, status, retry_count, trace_parent";
+
     private static final RowMapper<OutboxRow> ROW_MAPPER = new RowMapper<>() {
         @Override
         public OutboxRow mapRow(ResultSet rs, int rowNum) throws SQLException {
@@ -38,29 +42,34 @@ public class OutboxJdbcRepository {
                     .payload(rs.getString("payload"))
                     .status(OutboxStatus.fromCode(rs.getInt("status")))
                     .retryCount(rs.getInt("retry_count"))
+                    .traceParent(rs.getString("trace_parent"))
                     .build();
         }
     };
 
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
+    private final OutboxTracing outboxTracing;
 
-    public long insertEvent(Long orderId, Long customerId, String eventType, String payload, Instant now) {
-        Long id = jdbcTemplate.queryForObject(
-                """
-                        INSERT INTO outbox_events (order_id, customer_id, event_type, payload, status, retry_count, created_at)
-                        VALUES (?, ?, ?, ?::jsonb, ?, 0, ?)
-                        RETURNING id
-                        """,
-                Long.class,
-                orderId,
-                customerId,
-                eventType,
-                payload,
-                OutboxStatus.NEW.getCode(),
-                Timestamp.from(now)
-        );
-        return id;
+    public long insertEvent(Long orderId, Long customerId, String eventType, String payload, String traceParent, Instant now) {
+        return outboxTracing.observe("outbox.save", () -> {
+            Long id = jdbcTemplate.queryForObject(
+                    """
+                            INSERT INTO outbox_events (order_id, customer_id, event_type, payload, status, retry_count, trace_parent, created_at)
+                            VALUES (?, ?, ?, ?::jsonb, ?, 0, ?, ?)
+                            RETURNING id
+                            """,
+                    Long.class,
+                    orderId,
+                    customerId,
+                    eventType,
+                    payload,
+                    OutboxStatus.NEW.getCode(),
+                    traceParent,
+                    Timestamp.from(now)
+            );
+            return id;
+        });
     }
 
     /**
@@ -86,8 +95,8 @@ public class OutboxJdbcRepository {
                         WHERE id IN (%s)
                           AND status < ?
                           AND (locked_until IS NULL OR locked_until < NOW())
-                        RETURNING id, order_id, customer_id, event_type, payload::text AS payload, status, retry_count
-                        """.formatted(placeholders),
+                        RETURNING %s
+                        """.formatted(placeholders, OUTBOX_ROW_COLUMNS),
                 ROW_MAPPER,
                 params.toArray()
         );
@@ -97,23 +106,25 @@ public class OutboxJdbcRepository {
         if (ids.isEmpty()) {
             return;
         }
-        String placeholders = String.join(",", ids.stream().map(id -> "?").toList());
-        List<Object> params = new ArrayList<>();
-        params.add(OutboxStatus.SENT.getCode());
-        params.add(Timestamp.from(sentAt));
-        params.addAll(ids);
-        jdbcTemplate.update(
-                """
-                        UPDATE outbox_events
-                        SET status = ?, sent_at = ?, locked_by = NULL, locked_until = NULL
-                        WHERE id IN (%s)
-                        """.formatted(placeholders),
-                params.toArray()
-        );
+        outboxTracing.observe("outbox.mark.sent", () -> {
+            String placeholders = String.join(",", ids.stream().map(id -> "?").toList());
+            List<Object> params = new ArrayList<>();
+            params.add(OutboxStatus.SENT.getCode());
+            params.add(Timestamp.from(sentAt));
+            params.addAll(ids);
+            jdbcTemplate.update(
+                    """
+                            UPDATE outbox_events
+                            SET status = ?, sent_at = ?, locked_by = NULL, locked_until = NULL
+                            WHERE id IN (%s)
+                            """.formatted(placeholders),
+                    params.toArray()
+            );
+        });
     }
 
     public void markFailed(Long id, int retryCount, OutboxStatus status) {
-        jdbcTemplate.update(
+        outboxTracing.observe("outbox.retry", () -> jdbcTemplate.update(
                 """
                         UPDATE outbox_events
                         SET status = ?, retry_count = ?, locked_by = NULL, locked_until = NULL
@@ -122,7 +133,7 @@ public class OutboxJdbcRepository {
                 status.getCode(),
                 retryCount,
                 id
-        );
+        ));
     }
 
     /** Atomically selects recoverable rows and applies a short-lived lease; returns claimed ids. */
@@ -201,10 +212,10 @@ public class OutboxJdbcRepository {
     public Optional<OutboxRow> findById(long id) {
         List<OutboxRow> rows = jdbcTemplate.query(
                 """
-                        SELECT id, order_id, customer_id, event_type, payload::text AS payload, status, retry_count
+                        SELECT %s
                         FROM outbox_events
                         WHERE id = ?
-                        """,
+                        """.formatted(OUTBOX_ROW_COLUMNS),
                 ROW_MAPPER,
                 id
         );
@@ -222,6 +233,7 @@ public class OutboxJdbcRepository {
                     .eventType(row.getEventType())
                     .payload(payload)
                     .correlationId(correlationId)
+                    .traceParent(row.getTraceParent())
                     .occurredAt(Instant.now())
                     .build();
         } catch (Exception ex) {

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxRow.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxRow.java
@@ -35,4 +35,7 @@ public class OutboxRow {
 
     /** Number of failed publish attempts recorded for this row. */
     private final int retryCount;
+
+    /** W3C traceparent captured when the outbox row was created. */
+    private final String traceParent;
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/publisher/BatchPublisherWorker.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/publisher/BatchPublisherWorker.java
@@ -108,12 +108,12 @@ public class BatchPublisherWorker {
                                 .orElse(null);
                         outboxTracing.observeWithTraceParent(batchTraceParent, "outbox.batch.publish", () -> {
                             kafkaBatchPublisher.getObject().publish(envelopes);
+                            outboxJdbcRepository.markSent(sentIds(claimed), Instant.now());
+                            metrics.publishLatency().record(System.nanoTime() - start, java.util.concurrent.TimeUnit.NANOSECONDS);
+                            log.info("Kafka batch published size={} durationMs={}",
+                                    envelopes.size(),
+                                    (System.nanoTime() - start) / 1_000_000);
                         });
-                        outboxJdbcRepository.markSent(sentIds(claimed), Instant.now());
-                        metrics.publishLatency().record(System.nanoTime() - start, java.util.concurrent.TimeUnit.NANOSECONDS);
-                        log.info("Kafka batch published size={} durationMs={}",
-                                envelopes.size(),
-                                (System.nanoTime() - start) / 1_000_000);
                     } catch (Exception ex) {
                         metrics.incrementPublishFailures();
                         log.warn("Kafka batch publish failed size={} error={}", claimed.size(), ex.getMessage());

--- a/order-service/src/main/java/com/kholodilin/outbox/publisher/BatchPublisherWorker.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/publisher/BatchPublisherWorker.java
@@ -77,47 +77,51 @@ public class BatchPublisherWorker {
                 List<Long> drained = eventQueue.drainBatch(batchSize - 1);
                 ids.addAll(drained);
 
-                // Multi-pod safety: only rows we successfully claim are published.
-                Instant lockedUntil = Instant.now().plus(properties.getOutbox().getPublisher().getLeaseDuration());
-                List<OutboxRow> claimed = outboxTracing.observe("outbox.batch.fetch", () -> outboxJdbcRepository.claimByIds(
-                        ids,
-                        properties.getInstanceId(),
-                        lockedUntil
-                ));
-                if (claimed.isEmpty()) {
-                    log.debug("No outbox rows claimed for ids={}", ids);
-                    for (Long id : outboxJdbcRepository.findReenqueueableIds(ids)) {
-                        eventQueue.enqueue(id);
-                    }
-                    continue;
-                }
-
-                List<EventEnvelope> envelopes = new ArrayList<>();
-                for (OutboxRow row : claimed) {
-                    String correlationId = extractCorrelationId(row.getPayload());
-                    envelopes.add(outboxJdbcRepository.toEnvelope(row, correlationId));
-                }
-
-                long start = System.nanoTime();
                 try {
-                    String batchTraceParent = claimed.stream()
-                            .map(OutboxRow::getTraceParent)
-                            .filter(parent -> parent != null && !parent.isBlank())
-                            .findFirst()
-                            .orElse(null);
-                    outboxTracing.observeWithTraceParent(batchTraceParent, "outbox.batch.publish", () -> {
-                        kafkaBatchPublisher.getObject().publish(envelopes);
+                    // Multi-pod safety: only rows we successfully claim are published.
+                    Instant lockedUntil = Instant.now().plus(properties.getOutbox().getPublisher().getLeaseDuration());
+                    List<OutboxRow> claimed = outboxTracing.observe("outbox.batch.fetch", () -> outboxJdbcRepository.claimByIds(
+                            ids,
+                            properties.getInstanceId(),
+                            lockedUntil
+                    ));
+                    if (claimed.isEmpty()) {
+                        log.debug("No outbox rows claimed for ids={}", ids);
+                        for (Long id : outboxJdbcRepository.findReenqueueableIds(ids)) {
+                            eventQueue.enqueue(id);
+                        }
+                        continue;
+                    }
+
+                    List<EventEnvelope> envelopes = new ArrayList<>();
+                    for (OutboxRow row : claimed) {
+                        String correlationId = extractCorrelationId(row.getPayload());
+                        envelopes.add(outboxJdbcRepository.toEnvelope(row, correlationId));
+                    }
+
+                    long start = System.nanoTime();
+                    try {
+                        String batchTraceParent = claimed.stream()
+                                .map(OutboxRow::getTraceParent)
+                                .filter(parent -> parent != null && !parent.isBlank())
+                                .findFirst()
+                                .orElse(null);
+                        outboxTracing.observeWithTraceParent(batchTraceParent, "outbox.batch.publish", () -> {
+                            kafkaBatchPublisher.getObject().publish(envelopes);
+                        });
                         outboxJdbcRepository.markSent(sentIds(claimed), Instant.now());
-                    });
-                    metrics.publishLatency().record(System.nanoTime() - start, java.util.concurrent.TimeUnit.NANOSECONDS);
-                    log.info("Kafka batch published size={} durationMs={}",
-                            envelopes.size(),
-                            (System.nanoTime() - start) / 1_000_000);
-                } catch (Exception ex) {
-                    metrics.incrementPublishFailures();
-                    log.warn("Kafka batch publish failed size={} error={}", claimed.size(), ex.getMessage());
-                    log.debug("Kafka publish failure", ex);
-                    handleFailures(claimed);
+                        metrics.publishLatency().record(System.nanoTime() - start, java.util.concurrent.TimeUnit.NANOSECONDS);
+                        log.info("Kafka batch published size={} durationMs={}",
+                                envelopes.size(),
+                                (System.nanoTime() - start) / 1_000_000);
+                    } catch (Exception ex) {
+                        metrics.incrementPublishFailures();
+                        log.warn("Kafka batch publish failed size={} error={}", claimed.size(), ex.getMessage());
+                        log.debug("Kafka publish failure", ex);
+                        handleFailures(claimed);
+                    }
+                } finally {
+                    eventQueue.acknowledge(ids);
                 }
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();

--- a/order-service/src/main/java/com/kholodilin/outbox/publisher/BatchPublisherWorker.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/publisher/BatchPublisherWorker.java
@@ -8,6 +8,7 @@ import com.kholodilin.outbox.metrics.OutboxMetrics;
 import com.kholodilin.outbox.persistence.OutboxJdbcRepository;
 import com.kholodilin.outbox.persistence.OutboxRow;
 import com.kholodilin.outbox.queue.InMemoryEventQueue;
+import com.kholodilin.outbox.tracing.OutboxTracing;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class BatchPublisherWorker {
     private final OutboxJdbcRepository outboxJdbcRepository;
     private final ObjectProvider<KafkaBatchPublisher> kafkaBatchPublisher;
     private final OutboxMetrics metrics;
+    private final OutboxTracing outboxTracing;
     private final AppProperties properties;
     private final ObjectMapper objectMapper;
     private final AtomicBoolean running = new AtomicBoolean(true);
@@ -77,11 +79,11 @@ public class BatchPublisherWorker {
 
                 // Multi-pod safety: only rows we successfully claim are published.
                 Instant lockedUntil = Instant.now().plus(properties.getOutbox().getPublisher().getLeaseDuration());
-                List<OutboxRow> claimed = outboxJdbcRepository.claimByIds(
+                List<OutboxRow> claimed = outboxTracing.observe("outbox.batch.fetch", () -> outboxJdbcRepository.claimByIds(
                         ids,
                         properties.getInstanceId(),
                         lockedUntil
-                );
+                ));
                 if (claimed.isEmpty()) {
                     log.debug("No outbox rows claimed for ids={}", ids);
                     for (Long id : outboxJdbcRepository.findReenqueueableIds(ids)) {
@@ -98,9 +100,15 @@ public class BatchPublisherWorker {
 
                 long start = System.nanoTime();
                 try {
-                    kafkaBatchPublisher.getObject().publish(envelopes);
-                    List<Long> sentIds = claimed.stream().map(OutboxRow::getId).toList();
-                    outboxJdbcRepository.markSent(sentIds, Instant.now());
+                    String batchTraceParent = claimed.stream()
+                            .map(OutboxRow::getTraceParent)
+                            .filter(parent -> parent != null && !parent.isBlank())
+                            .findFirst()
+                            .orElse(null);
+                    outboxTracing.observeWithTraceParent(batchTraceParent, "outbox.batch.publish", () -> {
+                        kafkaBatchPublisher.getObject().publish(envelopes);
+                        outboxJdbcRepository.markSent(sentIds(claimed), Instant.now());
+                    });
                     metrics.publishLatency().record(System.nanoTime() - start, java.util.concurrent.TimeUnit.NANOSECONDS);
                     log.info("Kafka batch published size={} durationMs={}",
                             envelopes.size(),
@@ -118,6 +126,10 @@ public class BatchPublisherWorker {
                 log.error("Batch publisher loop error", ex);
             }
         }
+    }
+
+    private List<Long> sentIds(List<OutboxRow> claimed) {
+        return claimed.stream().map(OutboxRow::getId).toList();
     }
 
     private void handleFailures(List<OutboxRow> claimed) {

--- a/order-service/src/main/java/com/kholodilin/outbox/publisher/KafkaBatchPublisher.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/publisher/KafkaBatchPublisher.java
@@ -3,52 +3,113 @@ package com.kholodilin.outbox.publisher;
 import com.kholodilin.outbox.config.AppProperties;
 import com.kholodilin.outbox.events.EventConstants;
 import com.kholodilin.outbox.events.EventEnvelope;
-import lombok.RequiredArgsConstructor;
+import com.kholodilin.outbox.tracing.TraceContextSupport;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Sends a batch of {@link EventEnvelope} messages to Kafka.
  * <p>
  * Partition key is {@code customerId} so all events for one customer stay ordered per partition.
+ * Restores W3C trace context from each envelope before publishing and injects {@code traceparent} headers.
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class KafkaBatchPublisher {
+
+    private static final String TRACE_PARENT_KEY = "traceparent";
+    private static final String TRACE_STATE_KEY = "tracestate";
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final AppProperties properties;
+    private final TraceContextSupport traceContextSupport;
+    private final ObjectProvider<Tracer> tracerProvider;
+    private final ObjectProvider<Propagator> propagatorProvider;
+
+    public KafkaBatchPublisher(
+            KafkaTemplate<String, Object> kafkaTemplate,
+            AppProperties properties,
+            TraceContextSupport traceContextSupport,
+            ObjectProvider<Tracer> tracerProvider,
+            ObjectProvider<Propagator> propagatorProvider
+    ) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.properties = properties;
+        this.traceContextSupport = traceContextSupport;
+        this.tracerProvider = tracerProvider;
+        this.propagatorProvider = propagatorProvider;
+    }
 
     public void publish(List<EventEnvelope> envelopes) {
         String topic = properties.getKafka().getTopic();
         List<CompletableFuture<?>> futures = new ArrayList<>();
         for (EventEnvelope envelope : envelopes) {
-            String key = String.valueOf(envelope.getCustomerId());
-            ProducerRecord<String, Object> record = new ProducerRecord<>(topic, key, envelope);
-            // Headers allow consumers to route/trace without parsing the JSON body.
-            record.headers().add(new RecordHeader(EventConstants.HEADER_EVENT_ID, toBytes(envelope.getEventId())));
-            record.headers().add(new RecordHeader(EventConstants.HEADER_ORDER_ID, toBytes(envelope.getOrderId())));
-            record.headers().add(new RecordHeader(EventConstants.HEADER_CUSTOMER_ID, toBytes(envelope.getCustomerId())));
-            if (envelope.getCorrelationId() != null) {
-                record.headers().add(new RecordHeader(EventConstants.HEADER_CORRELATION_ID, envelope.getCorrelationId().getBytes(StandardCharsets.UTF_8)));
-            }
-            log.debug("Publishing to Kafka topic={} key={} eventId={}", topic, key, envelope.getEventId());
-            futures.add(kafkaTemplate.send(record));
+            traceContextSupport.runWithTraceParent(envelope.getTraceParent(), "outbox.publish", () -> {
+                String key = String.valueOf(envelope.getCustomerId());
+                ProducerRecord<String, Object> record = new ProducerRecord<>(topic, key, envelope);
+                addBusinessHeaders(record, envelope);
+                addTraceHeaders(record);
+                log.debug("Publishing to Kafka topic={} key={} eventId={}", topic, key, envelope.getEventId());
+                futures.add(kafkaTemplate.send(record));
+            });
         }
         CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
-        // Block until the whole batch is acknowledged by Kafka (sync batch semantics).
-        for (int i = 0; i < envelopes.size(); i++) {
-            EventEnvelope envelope = envelopes.get(i);
+        for (EventEnvelope envelope : envelopes) {
             log.debug("Kafka publish completed eventId={} partitionKey={}", envelope.getEventId(), envelope.getCustomerId());
+        }
+    }
+
+    private void addBusinessHeaders(ProducerRecord<String, Object> record, EventEnvelope envelope) {
+        record.headers().add(new RecordHeader(EventConstants.HEADER_EVENT_ID, toBytes(envelope.getEventId())));
+        record.headers().add(new RecordHeader(EventConstants.HEADER_ORDER_ID, toBytes(envelope.getOrderId())));
+        record.headers().add(new RecordHeader(EventConstants.HEADER_CUSTOMER_ID, toBytes(envelope.getCustomerId())));
+        if (envelope.getCorrelationId() != null) {
+            record.headers().add(new RecordHeader(
+                    EventConstants.HEADER_CORRELATION_ID,
+                    envelope.getCorrelationId().getBytes(StandardCharsets.UTF_8)
+            ));
+        }
+    }
+
+    private void addTraceHeaders(ProducerRecord<String, Object> record) {
+        Tracer tracer = tracerProvider.getIfAvailable();
+        Propagator propagator = propagatorProvider.getIfAvailable();
+        if (tracer == null || propagator == null) {
+            return;
+        }
+        Span current = tracer.currentSpan();
+        if (current == null) {
+            return;
+        }
+        Map<String, String> carrier = new HashMap<>();
+        propagator.inject(current.context(), carrier, Map::put);
+        String traceParent = carrier.get(TRACE_PARENT_KEY);
+        if (traceParent != null) {
+            record.headers().add(new RecordHeader(
+                    EventConstants.HEADER_TRACEPARENT,
+                    traceParent.getBytes(StandardCharsets.UTF_8)
+            ));
+        }
+        String traceState = carrier.get(TRACE_STATE_KEY);
+        if (traceState != null && !traceState.isBlank()) {
+            record.headers().add(new RecordHeader(
+                    EventConstants.HEADER_TRACESTATE,
+                    traceState.getBytes(StandardCharsets.UTF_8)
+            ));
         }
     }
 

--- a/order-service/src/main/java/com/kholodilin/outbox/queue/InMemoryEventQueue.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/queue/InMemoryEventQueue.java
@@ -32,6 +32,7 @@ public class InMemoryEventQueue {
 
     private BlockingQueue<Long> queue;
     private Set<Long> dedup;
+    private Set<Long> inFlight;
     private int capacity;
 
     @PostConstruct
@@ -39,6 +40,7 @@ public class InMemoryEventQueue {
         capacity = properties.getOutbox().getMemoryQueue().getCapacity();
         queue = new ArrayBlockingQueue<>(capacity);
         dedup = ConcurrentHashMap.newKeySet();
+        inFlight = ConcurrentHashMap.newKeySet();
         updateMetrics();
     }
 
@@ -69,6 +71,7 @@ public class InMemoryEventQueue {
         Long eventId = queue.poll(timeoutMs, TimeUnit.MILLISECONDS);
         if (eventId != null) {
             dedup.remove(eventId);
+            inFlight.add(eventId);
             updateMetrics();
         }
         return eventId;
@@ -80,10 +83,18 @@ public class InMemoryEventQueue {
         queue.drainTo(batch, batchSize);
         for (Long eventId : batch) {
             dedup.remove(eventId);
+            inFlight.add(eventId);
         }
         updateMetrics();
         log.debug("Drained batch size={} remaining={}", batch.size(), queue.size());
         return batch;
+    }
+
+    /** Called after publish completes (success or failure) so recovery can re-enqueue if needed. */
+    public void acknowledge(java.util.Collection<Long> eventIds) {
+        for (Long eventId : eventIds) {
+            inFlight.remove(eventId);
+        }
     }
 
     public int size() {
@@ -97,6 +108,11 @@ public class InMemoryEventQueue {
 
     public int capacity() {
         return capacity;
+    }
+
+    /** Returns true when the event id is already queued or being published. */
+    public boolean isTracked(long eventId) {
+        return dedup.contains(eventId) || inFlight.contains(eventId);
     }
 
     private void updateMetrics() {

--- a/order-service/src/main/java/com/kholodilin/outbox/recovery/RecoveryWorker.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/recovery/RecoveryWorker.java
@@ -4,6 +4,7 @@ import com.kholodilin.outbox.config.AppProperties;
 import com.kholodilin.outbox.metrics.OutboxMetrics;
 import com.kholodilin.outbox.persistence.OutboxJdbcRepository;
 import com.kholodilin.outbox.queue.InMemoryEventQueue;
+import com.kholodilin.outbox.tracing.OutboxTracing;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -27,12 +28,17 @@ public class RecoveryWorker {
     private final OutboxJdbcRepository outboxJdbcRepository;
     private final InMemoryEventQueue eventQueue;
     private final OutboxMetrics metrics;
+    private final OutboxTracing outboxTracing;
 
     @Scheduled(fixedDelayString = "${app.outbox.recovery.interval:10s}")
     public void recover() {
         if (!properties.getOutbox().getRecovery().isEnabled()) {
             return;
         }
+        outboxTracing.observe("outbox.recovery", this::recoverInternal);
+    }
+
+    private void recoverInternal() {
         int batchSize = properties.getOutbox().getRecovery().getBatchSize();
         Instant lockedUntil = Instant.now().plus(properties.getOutbox().getPublisher().getLeaseDuration());
         List<Long> ids = outboxJdbcRepository.claimRecoverableIds(

--- a/order-service/src/main/java/com/kholodilin/outbox/recovery/RecoveryWorker.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/recovery/RecoveryWorker.java
@@ -35,10 +35,7 @@ public class RecoveryWorker {
         if (!properties.getOutbox().getRecovery().isEnabled()) {
             return;
         }
-        outboxTracing.observe("outbox.recovery", this::recoverInternal);
-    }
 
-    private void recoverInternal() {
         int batchSize = properties.getOutbox().getRecovery().getBatchSize();
         Instant lockedUntil = Instant.now().plus(properties.getOutbox().getPublisher().getLeaseDuration());
         List<Long> ids = outboxJdbcRepository.claimRecoverableIds(
@@ -50,6 +47,10 @@ public class RecoveryWorker {
             return;
         }
 
+        outboxTracing.observe("outbox.recovery", () -> enqueueRecovered(ids, lockedUntil));
+    }
+
+    private void enqueueRecovered(List<Long> ids, Instant lockedUntil) {
         log.debug("Recovery claimed ids={} lockedBy={} lockedUntil={}", ids, properties.getInstanceId(), lockedUntil);
 
         // Release lease before enqueue so the publisher can claim rows as soon as it polls an id.

--- a/order-service/src/main/java/com/kholodilin/outbox/recovery/RecoveryWorker.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/recovery/RecoveryWorker.java
@@ -57,6 +57,9 @@ public class RecoveryWorker {
 
         int enqueued = 0;
         for (Long id : ids) {
+            if (eventQueue.isTracked(id)) {
+                continue;
+            }
             if (eventQueue.enqueue(id)) {
                 enqueued++;
             }

--- a/order-service/src/main/java/com/kholodilin/outbox/tracing/ActuatorTracingExclusionConfig.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/tracing/ActuatorTracingExclusionConfig.java
@@ -1,31 +1,67 @@
 package com.kholodilin.outbox.tracing;
 
+import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationPredicate;
+import io.micrometer.observation.ObservationView;
+import io.micrometer.tracing.exporter.SpanExportingPredicate;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
+import org.springframework.util.AntPathMatcher;
 
 @Configuration
 public class ActuatorTracingExclusionConfig {
 
-    private final String actuatorBasePath;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private final String actuatorPattern;
 
     public ActuatorTracingExclusionConfig(
             @Value("${management.endpoints.web.base-path:/actuator}") String actuatorBasePath) {
-        this.actuatorBasePath = actuatorBasePath.endsWith("/")
+        String normalized = actuatorBasePath.endsWith("/")
                 ? actuatorBasePath.substring(0, actuatorBasePath.length() - 1)
                 : actuatorBasePath;
+        this.actuatorPattern = normalized + "/**";
     }
 
     @Bean
     ObservationPredicate noActuatorObservationPredicate() {
-        return (name, context) -> {
-            if (context instanceof ServerRequestObservationContext serverContext) {
-                String uri = serverContext.getCarrier().getRequestURI();
-                return uri == null || !uri.startsWith(actuatorBasePath);
-            }
-            return true;
+        return (name, context) -> !matchesActuator(name, context);
+    }
+
+    @Bean
+    SpanExportingPredicate noActuatorSpanExportingPredicate() {
+        return span -> {
+            String name = span.getName();
+            return name == null || !name.contains("/actuator");
         };
+    }
+
+    private boolean matchesActuator(String name, Observation.Context context) {
+        if (name != null && name.contains("/actuator")) {
+            return true;
+        }
+
+        Observation.Context current = context;
+        while (current != null) {
+            if (current instanceof ServerRequestObservationContext serverContext) {
+                Object carrier = serverContext.getCarrier();
+                if (carrier instanceof HttpServletRequest request) {
+                    String uri = request.getRequestURI();
+                    if (uri != null && pathMatcher.match(actuatorPattern, uri)) {
+                        return true;
+                    }
+                }
+            }
+
+            ObservationView parentObservation = current.getParentObservation();
+            if (parentObservation == null) {
+                break;
+            }
+            current = (Observation.Context) parentObservation.getContextView();
+        }
+
+        return false;
     }
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/tracing/ActuatorTracingExclusionConfig.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/tracing/ActuatorTracingExclusionConfig.java
@@ -1,0 +1,31 @@
+package com.kholodilin.outbox.tracing;
+
+import io.micrometer.observation.ObservationPredicate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.observation.ServerRequestObservationContext;
+
+@Configuration
+public class ActuatorTracingExclusionConfig {
+
+    private final String actuatorBasePath;
+
+    public ActuatorTracingExclusionConfig(
+            @Value("${management.endpoints.web.base-path:/actuator}") String actuatorBasePath) {
+        this.actuatorBasePath = actuatorBasePath.endsWith("/")
+                ? actuatorBasePath.substring(0, actuatorBasePath.length() - 1)
+                : actuatorBasePath;
+    }
+
+    @Bean
+    ObservationPredicate noActuatorObservationPredicate() {
+        return (name, context) -> {
+            if (context instanceof ServerRequestObservationContext serverContext) {
+                String uri = serverContext.getCarrier().getRequestURI();
+                return uri == null || !uri.startsWith(actuatorBasePath);
+            }
+            return true;
+        };
+    }
+}

--- a/order-service/src/main/java/com/kholodilin/outbox/tracing/OutboxTracing.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/tracing/OutboxTracing.java
@@ -1,0 +1,52 @@
+package com.kholodilin.outbox.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Supplier;
+
+/**
+ * Dedicated spans for the outbox publishing pipeline (separate from Micrometer metrics).
+ * No-ops when Micrometer tracing is disabled.
+ */
+@Component
+public class OutboxTracing {
+
+    private final ObjectProvider<Tracer> tracerProvider;
+    private final TraceContextSupport traceContextSupport;
+
+    public OutboxTracing(ObjectProvider<Tracer> tracerProvider, TraceContextSupport traceContextSupport) {
+        this.tracerProvider = tracerProvider;
+        this.traceContextSupport = traceContextSupport;
+    }
+
+    public void observe(String spanName, Runnable action) {
+        observe(spanName, () -> {
+            action.run();
+            return null;
+        });
+    }
+
+    public <T> T observe(String spanName, Supplier<T> action) {
+        Tracer tracer = tracerProvider.getIfAvailable();
+        if (tracer == null) {
+            return action.get();
+        }
+        Span span = tracer.nextSpan().name(spanName).start();
+        try (Tracer.SpanInScope scope = tracer.withSpan(span)) {
+            return action.get();
+        } finally {
+            span.end();
+        }
+    }
+
+    public void observeWithTraceParent(String traceParent, String spanName, Runnable action) {
+        traceContextSupport.runWithTraceParent(traceParent, spanName, action);
+    }
+
+    public <T> T observeWithTraceParent(String traceParent, String spanName, Supplier<T> action) {
+        return traceContextSupport.runWithTraceParent(traceParent, spanName, action);
+    }
+}

--- a/order-service/src/main/java/com/kholodilin/outbox/tracing/RecoveryTracingConfig.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/tracing/RecoveryTracingConfig.java
@@ -1,0 +1,37 @@
+package com.kholodilin.outbox.tracing;
+
+import com.kholodilin.outbox.recovery.RecoveryWorker;
+import io.micrometer.observation.ObservationPredicate;
+import io.micrometer.tracing.exporter.SpanExportingPredicate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.support.ScheduledTaskObservationContext;
+
+@Configuration
+public class RecoveryTracingConfig {
+
+    private static final String RECOVERY_SCHEDULER_SPAN_PREFIX = "task recoveryWorker.";
+
+    @Bean
+    ObservationPredicate skipRecoverySchedulerObservation() {
+        return (name, context) -> !isRecoveryScheduler(name, context);
+    }
+
+    @Bean
+    SpanExportingPredicate noRecoverySchedulerSpanExportingPredicate() {
+        return span -> {
+            String name = span.getName();
+            return name == null || !name.startsWith(RECOVERY_SCHEDULER_SPAN_PREFIX);
+        };
+    }
+
+    private static boolean isRecoveryScheduler(String name, io.micrometer.observation.Observation.Context context) {
+        if (name != null && name.startsWith(RECOVERY_SCHEDULER_SPAN_PREFIX)) {
+            return true;
+        }
+        if (context instanceof ScheduledTaskObservationContext scheduledContext) {
+            return RecoveryWorker.class.isAssignableFrom(scheduledContext.getTargetClass());
+        }
+        return false;
+    }
+}

--- a/order-service/src/main/java/com/kholodilin/outbox/tracing/TraceContextSupport.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/tracing/TraceContextSupport.java
@@ -1,0 +1,95 @@
+package com.kholodilin.outbox.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Captures and restores W3C trace context for asynchronous outbox publishing.
+ * No-ops when Micrometer tracing is disabled (for example in the {@code test} profile).
+ */
+@Component
+public class TraceContextSupport {
+
+    private static final String TRACE_PARENT_KEY = "traceparent";
+    private static final String TRACE_STATE_KEY = "tracestate";
+
+    private final ObjectProvider<Tracer> tracerProvider;
+    private final ObjectProvider<Propagator> propagatorProvider;
+
+    public TraceContextSupport(ObjectProvider<Tracer> tracerProvider, ObjectProvider<Propagator> propagatorProvider) {
+        this.tracerProvider = tracerProvider;
+        this.propagatorProvider = propagatorProvider;
+    }
+
+    /**
+     * Serializes the current trace context as a W3C {@code traceparent} value, or {@code null} when absent.
+     */
+    public String captureTraceParent() {
+        Tracer tracer = tracerProvider.getIfAvailable();
+        Propagator propagator = propagatorProvider.getIfAvailable();
+        if (tracer == null || propagator == null) {
+            return null;
+        }
+        Span current = tracer.currentSpan();
+        if (current == null) {
+            return null;
+        }
+        Map<String, String> carrier = new HashMap<>();
+        propagator.inject(current.context(), carrier, Map::put);
+        return carrier.get(TRACE_PARENT_KEY);
+    }
+
+    /**
+     * Serializes optional W3C {@code tracestate} from the active span.
+     */
+    public String captureTraceState() {
+        Tracer tracer = tracerProvider.getIfAvailable();
+        Propagator propagator = propagatorProvider.getIfAvailable();
+        if (tracer == null || propagator == null) {
+            return null;
+        }
+        Span current = tracer.currentSpan();
+        if (current == null) {
+            return null;
+        }
+        Map<String, String> carrier = new HashMap<>();
+        propagator.inject(current.context(), carrier, Map::put);
+        return carrier.get(TRACE_STATE_KEY);
+    }
+
+    public void runWithTraceParent(String traceParent, String spanName, Runnable action) {
+        runWithTraceParent(traceParent, spanName, () -> {
+            action.run();
+            return null;
+        });
+    }
+
+    public <T> T runWithTraceParent(String traceParent, String spanName, Supplier<T> action) {
+        Tracer tracer = tracerProvider.getIfAvailable();
+        Propagator propagator = propagatorProvider.getIfAvailable();
+        if (tracer == null || propagator == null) {
+            return action.get();
+        }
+        Span span = startSpan(tracer, propagator, traceParent, spanName);
+        try (Tracer.SpanInScope scope = tracer.withSpan(span)) {
+            return action.get();
+        } finally {
+            span.end();
+        }
+    }
+
+    private Span startSpan(Tracer tracer, Propagator propagator, String traceParent, String spanName) {
+        if (traceParent == null || traceParent.isBlank()) {
+            return tracer.nextSpan().name(spanName).start();
+        }
+        Map<String, String> carrier = Map.of(TRACE_PARENT_KEY, traceParent);
+        return propagator.extract(carrier, Map::get).name(spanName).start();
+    }
+}

--- a/order-service/src/main/resources/application-dev.yml
+++ b/order-service/src/main/resources/application-dev.yml
@@ -7,8 +7,15 @@ management:
     sampling:
       probability: 1.0
   otlp:
+    metrics:
+      export:
+        enabled: false
+  opentelemetry:
     tracing:
-      endpoint: http://localhost:4318/v1/traces
+      export:
+        otlp:
+          endpoint: http://localhost:4318/v1/traces
+          timeout: 2s
 
 app:
   rate-limit:

--- a/order-service/src/main/resources/application-dev.yml
+++ b/order-service/src/main/resources/application-dev.yml
@@ -2,6 +2,14 @@ logging:
   level:
     com.kholodilin.outbox: DEBUG
 
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: http://localhost:4318/v1/traces
+
 app:
   rate-limit:
     global:

--- a/order-service/src/main/resources/application-prod.yml
+++ b/order-service/src/main/resources/application-prod.yml
@@ -2,3 +2,8 @@ logging:
   level:
     root: INFO
     com.kholodilin.outbox: INFO
+
+management:
+  tracing:
+    sampling:
+      probability: ${TRACING_SAMPLING:0.1}

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -40,9 +40,11 @@ management:
       probability: ${TRACING_SAMPLING:1.0}
     propagation:
       type: w3c
-  otlp:
+  opentelemetry:
     tracing:
-      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
+      export:
+        otlp:
+          endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
   observations:
     jdbc:
       enabled: true

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -17,6 +17,8 @@ spring:
     change-log: classpath:db/changelog/db.changelog-master.yaml
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP:localhost:9092}
+    template:
+      observation-enabled: true
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
@@ -32,6 +34,18 @@ management:
   endpoint:
     health:
       show-details: when_authorized
+  tracing:
+    enabled: ${TRACING_ENABLED:true}
+    sampling:
+      probability: ${TRACING_SAMPLING:1.0}
+    propagation:
+      type: w3c
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
+  observations:
+    jdbc:
+      enabled: true
 
 logging:
   level:

--- a/order-service/src/main/resources/db/changelog/changes/005-outbox-trace-parent.sql
+++ b/order-service/src/main/resources/db/changelog/changes/005-outbox-trace-parent.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset outbox:005-outbox-trace-parent
+ALTER TABLE outbox_events ADD COLUMN trace_parent VARCHAR(55);

--- a/order-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/order-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -11,3 +11,6 @@ databaseChangeLog:
   - include:
       file: changes/004-outbox-events.sql
       relativeToChangelogFile: true
+  - include:
+      file: changes/005-outbox-trace-parent.sql
+      relativeToChangelogFile: true

--- a/order-service/src/main/resources/logback-spring.xml
+++ b/order-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <springProperty scope="context" name="appName" source="spring.application.name"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %5p ${PID:- } --- [%15.15t] %-40.40logger{39} : traceId=%X{traceId:-} spanId=%X{spanId:-} %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/order-service/src/test/java/com/kholodilin/outbox/api/RateLimitIT.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/api/RateLimitIT.java
@@ -17,6 +17,8 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,21 +31,31 @@ class RateLimitIT extends AbstractIntegrationTest {
     private TestRestTemplate restTemplate;
 
     @Test
-    void burstRequestsReturn429() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(EventConstants.IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString());
-
+    void burstRequestsReturn429() throws Exception {
         Map<String, Object> body = Map.of(
                 "customerId", 99,
                 "items", List.of(Map.of("productId", "sku-1", "quantity", 1, "price", 1.00))
         );
 
-        ResponseEntity<Map> first = restTemplate.postForEntity("/api/v1/orders", new HttpEntity<>(body, headers), Map.class);
-        headers.set(EventConstants.IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString());
-        ResponseEntity<String> second = restTemplate.postForEntity("/api/v1/orders", new HttpEntity<>(body, headers), String.class);
+        HttpHeaders firstHeaders = new HttpHeaders();
+        firstHeaders.setContentType(MediaType.APPLICATION_JSON);
+        firstHeaders.set(EventConstants.IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString());
 
-        assertThat(first.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(second.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        HttpHeaders secondHeaders = new HttpHeaders();
+        secondHeaders.setContentType(MediaType.APPLICATION_JSON);
+        secondHeaders.set(EventConstants.IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString());
+
+        CompletableFuture<ResponseEntity<Map>> first = CompletableFuture.supplyAsync(() ->
+                restTemplate.postForEntity("/api/v1/orders", new HttpEntity<>(body, firstHeaders), Map.class)
+        );
+        CompletableFuture<ResponseEntity<String>> second = CompletableFuture.supplyAsync(() ->
+                restTemplate.postForEntity("/api/v1/orders", new HttpEntity<>(body, secondHeaders), String.class)
+        );
+
+        ResponseEntity<Map> firstResponse = first.get(30, TimeUnit.SECONDS);
+        ResponseEntity<String> secondResponse = second.get(30, TimeUnit.SECONDS);
+
+        assertThat(firstResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(secondResponse.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
     }
 }

--- a/order-service/src/test/java/com/kholodilin/outbox/api/RecoveryIT.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/api/RecoveryIT.java
@@ -30,6 +30,7 @@ class RecoveryIT extends AbstractIntegrationTest {
                 55L,
                 EventConstants.EVENT_TYPE_ORDER_CREATED,
                 "{\"orderId\":100,\"customerId\":55}",
+                null,
                 Instant.now()
         );
 

--- a/order-service/src/test/java/com/kholodilin/outbox/persistence/OutboxJdbcRepositoryTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/persistence/OutboxJdbcRepositoryTest.java
@@ -3,16 +3,38 @@ package com.kholodilin.outbox.persistence;
 import tools.jackson.databind.json.JsonMapper;
 import com.kholodilin.outbox.events.EventEnvelope;
 import com.kholodilin.outbox.events.OutboxStatus;
+import com.kholodilin.outbox.tracing.OutboxTracing;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import java.util.function.Supplier;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class OutboxJdbcRepositoryTest {
 
+    private final OutboxTracing outboxTracing = mock(OutboxTracing.class);
     private final OutboxJdbcRepository repository =
-            new OutboxJdbcRepository(mock(JdbcTemplate.class), JsonMapper.builder().build());
+            new OutboxJdbcRepository(mock(JdbcTemplate.class), JsonMapper.builder().build(), outboxTracing);
+
+    @BeforeEach
+    void setUpOutboxTracingPassthrough() {
+        when(outboxTracing.observe(anyString(), any(Supplier.class))).thenAnswer(invocation -> {
+            Supplier<?> supplier = invocation.getArgument(1);
+            return supplier.get();
+        });
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(1);
+            runnable.run();
+            return null;
+        }).when(outboxTracing).observe(anyString(), any(Runnable.class));
+    }
 
     @Test
     void toEnvelopeBuildsKafkaMessage() {
@@ -24,6 +46,7 @@ class OutboxJdbcRepositoryTest {
                 .payload("{\"orderId\":99,\"customerId\":10}")
                 .status(OutboxStatus.NEW)
                 .retryCount(0)
+                .traceParent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
                 .build();
 
         EventEnvelope envelope = repository.toEnvelope(row, "corr-1");
@@ -33,6 +56,7 @@ class OutboxJdbcRepositoryTest {
         assertThat(envelope.getCustomerId()).isEqualTo(10L);
         assertThat(envelope.getEventType()).isEqualTo("OrderCreated");
         assertThat(envelope.getCorrelationId()).isEqualTo("corr-1");
+        assertThat(envelope.getTraceParent()).isEqualTo("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
         assertThat(envelope.getPayload()).containsEntry("orderId", 99);
     }
 }

--- a/order-service/src/test/java/com/kholodilin/outbox/publisher/BatchPublisherWorkerTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/publisher/BatchPublisherWorkerTest.java
@@ -9,6 +9,7 @@ import com.kholodilin.outbox.metrics.OutboxMetrics;
 import com.kholodilin.outbox.persistence.OutboxRow;
 import com.kholodilin.outbox.persistence.OutboxJdbcRepository;
 import com.kholodilin.outbox.queue.InMemoryEventQueue;
+import com.kholodilin.outbox.tracing.OutboxTracing;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
@@ -38,11 +41,20 @@ class BatchPublisherWorkerTest {
     @Mock
     private ObjectProvider<KafkaBatchPublisher> kafkaBatchPublisherProvider;
 
+    @Mock
+    private OutboxTracing outboxTracing;
+
     private BatchPublisherWorker worker;
 
     @BeforeEach
     void setUp() {
         lenient().when(kafkaBatchPublisherProvider.getObject()).thenReturn(kafkaBatchPublisher);
+        lenient().when(outboxTracing.observe(anyString(), any(java.util.function.Supplier.class)))
+                .thenAnswer(invocation -> invocation.getArgument(1, java.util.function.Supplier.class).get());
+        lenient().doAnswer(invocation -> {
+            invocation.getArgument(2, Runnable.class).run();
+            return null;
+        }).when(outboxTracing).observeWithTraceParent(any(), anyString(), any(Runnable.class));
         OutboxMetrics metrics = new OutboxMetrics(new SimpleMeterRegistry());
         ReflectionTestUtils.invokeMethod(metrics, "registerMeters");
         AppProperties properties = AppProperties.builder()
@@ -55,6 +67,7 @@ class BatchPublisherWorkerTest {
                 outboxJdbcRepository,
                 kafkaBatchPublisherProvider,
                 metrics,
+                outboxTracing,
                 properties,
                 JsonMapper.builder().build()
         );

--- a/order-service/src/test/java/com/kholodilin/outbox/publisher/KafkaBatchPublisherTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/publisher/KafkaBatchPublisherTest.java
@@ -4,16 +4,26 @@ import com.kholodilin.outbox.config.AppProperties;
 import com.kholodilin.outbox.config.KafkaProperties;
 import com.kholodilin.outbox.events.EventConstants;
 import com.kholodilin.outbox.events.EventEnvelope;
+import com.kholodilin.outbox.tracing.TraceContextSupport;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -21,37 +31,88 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class KafkaBatchPublisherTest {
+
+    private static final String TRACE_PARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
 
     @Mock
     private KafkaTemplate<String, Object> kafkaTemplate;
 
+    @Mock
+    private Tracer tracer;
+
+    @Mock
+    private Propagator propagator;
+
+    @Mock
+    private ObjectProvider<Tracer> tracerProvider;
+
+    @Mock
+    private ObjectProvider<Propagator> propagatorProvider;
+
+    @Mock
+    private Span nextSpan;
+
+    @Mock
+    private Span childSpan;
+
+    @Mock
+    private Span.Builder spanBuilder;
+
+    @Mock
+    private Tracer.SpanInScope spanInScope;
+
+    @Mock
+    private TraceContext traceContext;
+
+    private TraceContextSupport traceContextSupport;
     private KafkaBatchPublisher publisher;
 
     @BeforeEach
     void setUp() {
+        when(tracerProvider.getIfAvailable()).thenReturn(tracer);
+        when(propagatorProvider.getIfAvailable()).thenReturn(propagator);
+        when(tracer.nextSpan()).thenReturn(nextSpan);
+        when(nextSpan.name(any())).thenReturn(nextSpan);
+        when(nextSpan.start()).thenReturn(childSpan);
+        when(propagator.extract(any(), any())).thenReturn(spanBuilder);
+        when(spanBuilder.name(any())).thenReturn(spanBuilder);
+        when(spanBuilder.start()).thenReturn(childSpan);
+        when(tracer.withSpan(childSpan)).thenReturn(spanInScope);
+        when(tracer.currentSpan()).thenReturn(childSpan);
+        when(childSpan.context()).thenReturn(traceContext);
+        traceContextSupport = new TraceContextSupport(tracerProvider, propagatorProvider);
         AppProperties properties = new AppProperties();
         KafkaProperties kafka = new KafkaProperties();
         kafka.setTopic(EventConstants.TOPIC_ORDERS);
         properties.setKafka(kafka);
-        publisher = new KafkaBatchPublisher(kafkaTemplate, properties);
+        publisher = new KafkaBatchPublisher(
+                kafkaTemplate,
+                properties,
+                traceContextSupport,
+                tracerProvider,
+                propagatorProvider
+        );
+
         when(kafkaTemplate.send(any(ProducerRecord.class)))
                 .thenReturn(CompletableFuture.completedFuture(new SendResult<>(null, null)));
+
+        doAnswer(invocation -> {
+            Map<String, String> map = invocation.getArgument(1);
+            map.put("traceparent", TRACE_PARENT);
+            return null;
+        }).when(propagator).inject(eq(traceContext), any(), any());
     }
 
     @Test
     void usesCustomerIdAsPartitionKey() {
-        EventEnvelope envelope = EventEnvelope.builder()
-                .eventId(1L)
-                .orderId(10L)
-                .customerId(42L)
-                .eventType(EventConstants.EVENT_TYPE_ORDER_CREATED)
-                .payload(Map.of("orderId", 10))
-                .occurredAt(Instant.parse("2026-07-12T10:00:00Z"))
-                .build();
+        EventEnvelope envelope = sampleEnvelope(null);
 
         publisher.publish(List.of(envelope));
 
@@ -60,5 +121,30 @@ class KafkaBatchPublisherTest {
         assertThat(captor.getValue().topic()).isEqualTo(EventConstants.TOPIC_ORDERS);
         assertThat(captor.getValue().key()).isEqualTo("42");
         assertThat(captor.getValue().value()).isEqualTo(envelope);
+    }
+
+    @Test
+    void addsTraceparentHeaderWhenSpanIsActive() {
+        EventEnvelope envelope = sampleEnvelope(TRACE_PARENT);
+
+        publisher.publish(List.of(envelope));
+
+        ArgumentCaptor<ProducerRecord<String, Object>> captor = ArgumentCaptor.forClass(ProducerRecord.class);
+        org.mockito.Mockito.verify(kafkaTemplate).send(captor.capture());
+        Header header = captor.getValue().headers().lastHeader(EventConstants.HEADER_TRACEPARENT);
+        assertThat(header).isNotNull();
+        assertThat(new String(header.value(), StandardCharsets.UTF_8)).isEqualTo(TRACE_PARENT);
+    }
+
+    private EventEnvelope sampleEnvelope(String traceParent) {
+        return EventEnvelope.builder()
+                .eventId(1L)
+                .orderId(10L)
+                .customerId(42L)
+                .eventType(EventConstants.EVENT_TYPE_ORDER_CREATED)
+                .payload(Map.of("orderId", 10))
+                .traceParent(traceParent)
+                .occurredAt(Instant.parse("2026-07-12T10:00:00Z"))
+                .build();
     }
 }

--- a/order-service/src/test/java/com/kholodilin/outbox/tracing/TraceContextSupportTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/tracing/TraceContextSupportTest.java
@@ -1,0 +1,117 @@
+package com.kholodilin.outbox.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TraceContextSupportTest {
+
+    private static final String TRACE_PARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+    @Mock
+    private Tracer tracer;
+
+    @Mock
+    private Propagator propagator;
+
+    @Mock
+    private ObjectProvider<Tracer> tracerProvider;
+
+    @Mock
+    private ObjectProvider<Propagator> propagatorProvider;
+
+    @Mock
+    private Span currentSpan;
+
+    @Mock
+    private Span childSpan;
+
+    @Mock
+    private TraceContext traceContext;
+
+    @Mock
+    private Span.Builder spanBuilder;
+
+    @Mock
+    private Tracer.SpanInScope spanInScope;
+
+    private TraceContextSupport traceContextSupport;
+
+    @BeforeEach
+    void setUp() {
+        when(tracerProvider.getIfAvailable()).thenReturn(tracer);
+        when(propagatorProvider.getIfAvailable()).thenReturn(propagator);
+        traceContextSupport = new TraceContextSupport(tracerProvider, propagatorProvider);
+    }
+
+    @Test
+    void captureTraceParentReturnsInjectedValue() {
+        when(tracer.currentSpan()).thenReturn(currentSpan);
+        when(currentSpan.context()).thenReturn(traceContext);
+        doAnswer(invocation -> {
+            Map<String, String> carrier = invocation.getArgument(1);
+            carrier.put("traceparent", TRACE_PARENT);
+            return null;
+        }).when(propagator).inject(eq(traceContext), any(), any());
+
+        assertThat(traceContextSupport.captureTraceParent()).isEqualTo(TRACE_PARENT);
+    }
+
+    @Test
+    void captureTraceParentReturnsNullWhenNoActiveSpan() {
+        when(tracer.currentSpan()).thenReturn(null);
+
+        assertThat(traceContextSupport.captureTraceParent()).isNull();
+    }
+
+    @Test
+    void runWithTraceParentRestoresContext() {
+        when(propagator.extract(any(), any())).thenReturn(spanBuilder);
+        when(spanBuilder.name("outbox.publish")).thenReturn(spanBuilder);
+        when(spanBuilder.start()).thenReturn(childSpan);
+        when(tracer.withSpan(childSpan)).thenReturn(spanInScope);
+
+        AtomicReference<String> traceParentSeen = new AtomicReference<>();
+        traceContextSupport.runWithTraceParent(TRACE_PARENT, "outbox.publish", () -> traceParentSeen.set("ran"));
+
+        assertThat(traceParentSeen).hasValue("ran");
+        ArgumentCaptor<Map<String, String>> carrierCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(propagator).extract(carrierCaptor.capture(), any());
+        assertThat(carrierCaptor.getValue()).containsEntry("traceparent", TRACE_PARENT);
+        verify(childSpan).end();
+    }
+
+    @Test
+    void runWithTraceParentNoOpsWhenTracingDisabled() {
+        ObjectProvider<Tracer> emptyTracer = org.mockito.Mockito.mock(ObjectProvider.class);
+        ObjectProvider<Propagator> emptyPropagator = org.mockito.Mockito.mock(ObjectProvider.class);
+        when(emptyTracer.getIfAvailable()).thenReturn(null);
+        when(emptyPropagator.getIfAvailable()).thenReturn(null);
+        TraceContextSupport disabled = new TraceContextSupport(emptyTracer, emptyPropagator);
+        AtomicReference<String> seen = new AtomicReference<>();
+        disabled.runWithTraceParent(TRACE_PARENT, "outbox.publish", () -> seen.set("ran"));
+        assertThat(seen).hasValue("ran");
+    }
+}

--- a/order-service/src/test/resources/application-test.yml
+++ b/order-service/src/test/resources/application-test.yml
@@ -8,6 +8,10 @@ spring:
   liquibase:
     enabled: true
 
+management:
+  tracing:
+    enabled: false
+
 app:
   outbox:
     recovery:

--- a/order-service/src/test/resources/application-test.yml
+++ b/order-service/src/test/resources/application-test.yml
@@ -9,6 +9,8 @@ spring:
     enabled: true
 
 management:
+  opentelemetry:
+    enabled: false
   tracing:
     enabled: false
 

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventConstants.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventConstants.java
@@ -29,6 +29,12 @@ public final class EventConstants {
     /** Kafka / tracing header with the client-supplied correlation id. */
     public static final String HEADER_CORRELATION_ID = "correlationId";
 
+    /** W3C trace context propagated through Kafka (see {@code traceparent}). */
+    public static final String HEADER_TRACEPARENT = "traceparent";
+
+    /** Optional W3C tracestate header propagated through Kafka. */
+    public static final String HEADER_TRACESTATE = "tracestate";
+
     /** HTTP header name for idempotent order creation requests. */
     public static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
 

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventEnvelope.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventEnvelope.java
@@ -1,5 +1,6 @@
 package com.kholodilin.outbox.events;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,4 +40,12 @@ public class EventEnvelope {
 
     /** UTC timestamp when the envelope was assembled for publishing. */
     private Instant occurredAt;
+
+    /** W3C traceparent restored from outbox row; not serialized in the Kafka JSON body. */
+    @JsonIgnore
+    private String traceParent;
+
+    /** Optional W3C tracestate; not serialized in the Kafka JSON body. */
+    @JsonIgnore
+    private String traceState;
 }


### PR DESCRIPTION
## Summary

- Add Micrometer + OpenTelemetry tracing to `order-service` and `notification-stub` with W3C propagation, OTLP export to Grafana Tempo, and tracing disabled in the `test` profile for CI.
- Persist `trace_parent` on outbox events (Liquibase 005), restore context in the publisher pipeline, inject `traceparent`/`tracestate` Kafka headers, and add outbox-specific spans (`outbox.save`, `outbox.batch.fetch`, `outbox.publish`, etc.).
- Provision Tempo in `docker-compose`, Grafana Tempo datasource, **Distributed Tracing** dashboard, and `traceId`/`spanId` in logback patterns.

Closes #14

## Test plan

- [x] `mvn clean verify` (unit + integration tests; tracing off in test profile)
- [ ] Manual: `docker compose up -d` → start services with `dev` profile → `POST /api/v1/orders` → Grafana → **Distributed Tracing** dashboard → verify end-to-end trace (HTTP → outbox → Kafka → notification-stub)

## Affected modules

- [x] `outbox-events-contract`
- [x] `order-service`
- [x] `notification-stub`
- [x] `docker-compose` / infrastructure
- [x] docs / CI / other