### PR TITLE
Transactional Outbox Pattern with Kafka - Fix flaky RateLimitIT.burstRequestsReturn429 in CI

### DIFF
--- a/order-service/src/test/java/com/kholodilin/outbox/api/RateLimitIT.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/api/RateLimitIT.java
@@ -55,7 +55,8 @@ class RateLimitIT extends AbstractIntegrationTest {
         ResponseEntity<Map> firstResponse = first.get(30, TimeUnit.SECONDS);
         ResponseEntity<String> secondResponse = second.get(30, TimeUnit.SECONDS);
 
-        assertThat(firstResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(secondResponse.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        // With capacity=1 buckets, either parallel request may win the token.
+        assertThat(List.of(firstResponse.getStatusCode(), secondResponse.getStatusCode()))
+                .containsExactlyInAnyOrder(HttpStatus.CREATED, HttpStatus.TOO_MANY_REQUESTS);
     }
 }


### PR DESCRIPTION
## Summary

- Fix non-deterministic assertion in `RateLimitIT.burstRequestsReturn429` after parallel burst was introduced in `fe2b47e`
- Assert exactly one `201 CREATED` and one `429 TOO_MANY_REQUESTS` regardless of which CompletableFuture completes first

Closes #16

## Test plan

- [x] `mvn -pl order-service -am verify`
- [x] `mvn -pl order-service -Dit.test=RateLimitIT verify` (3 consecutive runs)