### PR TITLE
chore: clean unused code, deps, and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 logs/
+*.log
 .idea/
 *.iml
 .classpath

--- a/notification-stub/pom.xml
+++ b/notification-stub/pom.xml
@@ -43,6 +43,11 @@
             <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>

--- a/notification-stub/src/main/resources/logback-spring.xml
+++ b/notification-stub/src/main/resources/logback-spring.xml
@@ -7,6 +7,7 @@
     <springProperty scope="context" name="deployEnv" source="deployment.environment" defaultValue="local"/>
     <springProperty scope="context" name="serviceVersion" source="info.app.version" defaultValue="1.0.0-SNAPSHOT"/>
     <springProperty scope="context" name="jsonLogPath" source="app.logging.json.path" defaultValue="./logs"/>
+    <springProperty scope="context" name="jsonLogEnabled" source="app.logging.json.enabled" defaultValue="true"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -61,9 +62,18 @@
     </springProfile>
 
     <springProfile name="!test">
-        <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="JSON_FILE"/>
-        </root>
+        <if condition='property("jsonLogEnabled").equalsIgnoreCase("true")'>
+            <then>
+                <root level="INFO">
+                    <appender-ref ref="CONSOLE"/>
+                    <appender-ref ref="JSON_FILE"/>
+                </root>
+            </then>
+            <else>
+                <root level="INFO">
+                    <appender-ref ref="CONSOLE"/>
+                </root>
+            </else>
+        </if>
     </springProfile>
 </configuration>

--- a/notification-stub/src/test/java/com/kholodilin/outbox/notification/NotificationStubHandlerTest.java
+++ b/notification-stub/src/test/java/com/kholodilin/outbox/notification/NotificationStubHandlerTest.java
@@ -55,7 +55,6 @@ class NotificationStubHandlerTest {
                 Map.of("orderId", 2),
                 "corr",
                 null,
-                null,
                 null
         );
         ConsumerRecord<String, EventEnvelope> record = new ConsumerRecord<>("orders.events", 0, 5L, "3", envelope);
@@ -80,7 +79,6 @@ class NotificationStubHandlerTest {
                 7L,
                 "OrderCreated",
                 Map.of("orderId", 6),
-                null,
                 null,
                 null,
                 null

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -79,14 +79,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-restclient</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka-test</artifactId>
-            <scope>test</scope>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/order-service/src/main/java/com/kholodilin/outbox/config/AppConfig.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/AppConfig.java
@@ -5,12 +5,10 @@ import tools.jackson.databind.ObjectMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableAsync;
 
 /** Spring beans shared by the order service (JSON mapper, Kafka producer template). */
 @Configuration
 @EnableConfigurationProperties(AppProperties.class)
-@EnableAsync
 public class AppConfig {
 
     /**

--- a/order-service/src/main/java/com/kholodilin/outbox/config/PublisherProperties.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/config/PublisherProperties.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 
 import java.time.Duration;
 
-/** Batch publisher lease, retry, and poll interval. */
+/** Batch publisher lease and retry settings. */
 @Getter
 @Setter
 @Builder
@@ -23,8 +23,4 @@ public class PublisherProperties {
     /** Failed publish attempts after which a row is moved to {@code DEAD}. */
     @Builder.Default
     private int maxRetries = 5;
-
-    /** Reserved poll interval for future publisher tuning. */
-    @Builder.Default
-    private Duration pollInterval = Duration.ofMillis(100);
 }

--- a/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxJdbcRepository.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/persistence/OutboxJdbcRepository.java
@@ -309,8 +309,7 @@ public class OutboxJdbcRepository {
                     payload,
                     correlationId,
                     Instant.now(),
-                    row.traceParent(),
-                    null
+                    row.traceParent()
             );
         } catch (Exception ex) {
             throw new IllegalStateException("Failed to parse outbox payload for id=" + row.id(), ex);

--- a/order-service/src/main/java/com/kholodilin/outbox/tracing/TraceContextSupport.java
+++ b/order-service/src/main/java/com/kholodilin/outbox/tracing/TraceContextSupport.java
@@ -27,9 +27,6 @@ import java.util.function.Supplier;
  * Micrometer {@link Propagator} and starts a child span under the original parent —
  * continuing the same {@code traceId}.
  * <p>
- * Optional {@link #captureTraceState()} covers the W3C {@code tracestate} vendor bag; it is
- * available for Kafka header propagation even when the DB column stores only {@code traceparent}.
- * <p>
  * <b>Exceptions.</b>
  * No try/catch around {@code action}. Failures bubble to the publisher/recovery caller so
  * retry / FAILED / DEAD status handling stays unchanged. {@link Span#end()} always runs in
@@ -46,7 +43,6 @@ import java.util.function.Supplier;
 public class TraceContextSupport {
 
     private static final String TRACE_PARENT_KEY = "traceparent";
-    private static final String TRACE_STATE_KEY = "tracestate";
 
     private final ObjectProvider<Tracer> tracerProvider;
     private final ObjectProvider<Propagator> propagatorProvider;
@@ -78,30 +74,6 @@ public class TraceContextSupport {
         Map<String, String> carrier = new HashMap<>();
         propagator.inject(current.context(), carrier, Map::put);
         return carrier.get(TRACE_PARENT_KEY);
-    }
-
-    /**
-     * Serializes optional W3C {@code tracestate} from the active span.
-     * <p>
-     * Used when propagating context into Kafka headers alongside {@code traceparent}.
-     * Not required for the DB column; returns {@code null} under the same conditions as
-     * {@link #captureTraceParent()}.
-     *
-     * @return W3C tracestate string, or {@code null} when absent
-     */
-    public String captureTraceState() {
-        Tracer tracer = tracerProvider.getIfAvailable();
-        Propagator propagator = propagatorProvider.getIfAvailable();
-        if (tracer == null || propagator == null) {
-            return null;
-        }
-        Span current = tracer.currentSpan();
-        if (current == null) {
-            return null;
-        }
-        Map<String, String> carrier = new HashMap<>();
-        propagator.inject(current.context(), carrier, Map::put);
-        return carrier.get(TRACE_STATE_KEY);
     }
 
     /**

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     username: ${DB_USER:outbox}
     password: ${DB_PASSWORD:outbox}
     hikari:
-      maximum-pool-size: 90
+      maximum-pool-size: 50
       connection-init-sql: SET TIME ZONE 'UTC'
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
@@ -48,9 +48,6 @@ management:
       export:
         otlp:
           endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
-  observations:
-    jdbc:
-      enabled: true
 
 logging:
   level:
@@ -77,7 +74,6 @@ app:
     publisher:
       lease-duration: 30s
       max-retries: 5
-      poll-interval: 100ms
     recovery:
       enabled: true
       interval: 10s

--- a/order-service/src/main/resources/logback-spring.xml
+++ b/order-service/src/main/resources/logback-spring.xml
@@ -7,6 +7,7 @@
     <springProperty scope="context" name="deployEnv" source="deployment.environment" defaultValue="local"/>
     <springProperty scope="context" name="serviceVersion" source="info.app.version" defaultValue="1.0.0-SNAPSHOT"/>
     <springProperty scope="context" name="jsonLogPath" source="app.logging.json.path" defaultValue="./logs"/>
+    <springProperty scope="context" name="jsonLogEnabled" source="app.logging.json.enabled" defaultValue="true"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -61,9 +62,18 @@
     </springProfile>
 
     <springProfile name="!test">
-        <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="JSON_FILE"/>
-        </root>
+        <if condition='property("jsonLogEnabled").equalsIgnoreCase("true")'>
+            <then>
+                <root level="INFO">
+                    <appender-ref ref="CONSOLE"/>
+                    <appender-ref ref="JSON_FILE"/>
+                </root>
+            </then>
+            <else>
+                <root level="INFO">
+                    <appender-ref ref="CONSOLE"/>
+                </root>
+            </else>
+        </if>
     </springProfile>
 </configuration>

--- a/order-service/src/test/java/com/kholodilin/outbox/config/KafkaProducerConfigTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/config/KafkaProducerConfigTest.java
@@ -22,7 +22,6 @@ class KafkaProducerConfigTest {
                 Map.of("orderId", 10),
                 null,
                 Instant.parse("2026-07-12T10:15:30Z"),
-                null,
                 null
         );
 

--- a/order-service/src/test/java/com/kholodilin/outbox/publisher/BatchPublisherWorkerTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/publisher/BatchPublisherWorkerTest.java
@@ -143,7 +143,7 @@ class BatchPublisherWorkerTest {
     void loopPublishesClaimedBatchAndAcknowledges() throws Exception {
         OutboxRow row = sampleRow(0);
         EventEnvelope envelope = new EventEnvelope(
-                1L, 10L, 20L, "OrderCreated", Map.of("orderId", 10), "corr", Instant.now(), "00-trace", null);
+                1L, 10L, 20L, "OrderCreated", Map.of("orderId", 10), "corr", Instant.now(), "00-trace");
         AtomicInteger polls = new AtomicInteger();
         when(eventQueue.poll(anyLong())).thenAnswer(invocation -> {
             if (polls.getAndIncrement() == 0) {
@@ -187,7 +187,7 @@ class BatchPublisherWorkerTest {
     void loopMarksFailedWhenPublishThrows() throws Exception {
         OutboxRow row = sampleRow(1);
         EventEnvelope envelope = new EventEnvelope(
-                1L, 10L, 20L, "OrderCreated", Map.of(), null, Instant.now(), null, null);
+                1L, 10L, 20L, "OrderCreated", Map.of(), null, Instant.now(), null);
         AtomicInteger polls = new AtomicInteger();
         when(eventQueue.poll(anyLong())).thenAnswer(invocation -> {
             if (polls.getAndIncrement() == 0) {

--- a/order-service/src/test/java/com/kholodilin/outbox/publisher/KafkaBatchPublisherTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/publisher/KafkaBatchPublisherTest.java
@@ -146,7 +146,6 @@ class KafkaBatchPublisherTest {
                 Map.of("orderId", 10),
                 "corr-99",
                 Instant.parse("2026-07-12T10:00:00Z"),
-                null,
                 null
         );
 
@@ -187,8 +186,7 @@ class KafkaBatchPublisherTest {
                 Map.of("orderId", 10),
                 null,
                 Instant.parse("2026-07-12T10:00:00Z"),
-                traceParent,
-                null
+                traceParent
         );
     }
 }

--- a/order-service/src/test/java/com/kholodilin/outbox/tracing/TraceContextSupportTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/tracing/TraceContextSupportTest.java
@@ -87,27 +87,13 @@ class TraceContextSupportTest {
     }
 
     @Test
-    void captureTraceStateReturnsInjectedValue() {
-        when(tracer.currentSpan()).thenReturn(currentSpan);
-        when(currentSpan.context()).thenReturn(traceContext);
-        doAnswer(invocation -> {
-            Map<String, String> carrier = invocation.getArgument(1);
-            carrier.put("tracestate", "vendor=1");
-            return null;
-        }).when(propagator).inject(eq(traceContext), any(), any());
-
-        assertThat(traceContextSupport.captureTraceState()).isEqualTo("vendor=1");
-    }
-
-    @Test
-    void captureTraceStateReturnsNullWhenDisabled() {
+    void captureTraceParentReturnsNullWhenTracingDisabled() {
         ObjectProvider<Tracer> emptyTracer = org.mockito.Mockito.mock(ObjectProvider.class);
         ObjectProvider<Propagator> emptyPropagator = org.mockito.Mockito.mock(ObjectProvider.class);
         when(emptyTracer.getIfAvailable()).thenReturn(null);
         when(emptyPropagator.getIfAvailable()).thenReturn(null);
         TraceContextSupport disabled = new TraceContextSupport(emptyTracer, emptyPropagator);
 
-        assertThat(disabled.captureTraceState()).isNull();
         assertThat(disabled.captureTraceParent()).isNull();
     }
 

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventConstants.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventConstants.java
@@ -14,9 +14,6 @@ public final class EventConstants {
     /** Event type emitted when a new order is accepted. */
     public static final String EVENT_TYPE_ORDER_CREATED = "OrderCreated";
 
-    /** Kafka record key field — all events for one customer land in the same partition. */
-    public static final String PARTITION_KEY_FIELD = "customerId";
-
     /** Kafka / tracing header with the outbox event id. */
     public static final String HEADER_EVENT_ID = "eventId";
 

--- a/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventEnvelope.java
+++ b/outbox-events-contract/src/main/java/com/kholodilin/outbox/events/EventEnvelope.java
@@ -34,10 +34,6 @@ public record EventEnvelope(
 
         /** W3C traceparent restored from outbox row; not serialized in the Kafka JSON body. */
         @JsonIgnore
-        String traceParent,
-
-        /** Optional W3C tracestate; not serialized in the Kafka JSON body. */
-        @JsonIgnore
-        String traceState
+        String traceParent
 ) {
 }

--- a/outbox-events-contract/src/test/java/com/kholodilin/outbox/events/EventEnvelopeTest.java
+++ b/outbox-events-contract/src/test/java/com/kholodilin/outbox/events/EventEnvelopeTest.java
@@ -20,8 +20,7 @@ class EventEnvelopeTest {
                 Map.of("orderId", 2),
                 "corr",
                 now,
-                "00-trace",
-                null
+                "00-trace"
         );
 
         assertThat(envelope.eventId()).isEqualTo(1L);


### PR DESCRIPTION
## Summary
Closes #27.

- Remove unused `@EnableAsync`, `poll-interval`, dead test deps (`spring-boot-restclient`, `spring-kafka-test`)
- Drop unbound `management.observations.jdbc.enabled` (Hikari metrics unchanged)
- Wire `app.logging.json.enabled` to logback `JSON_FILE` (console stays; OpenSearch path gated)
- Remove `PARTITION_KEY_FIELD`, `captureTraceState()`, unused `EventEnvelope.traceState`
- Set Hikari pool to **50**; ignore `*.log`

## Test plan
- [x] `mvn verify`
- [x] Gatling smoke (`rps*=10`)
- [x] Gatling flat 100 RPS (pool=50): ~97 RPS, P95 ~279 ms, 0% failed