### PR TITLE
Update CONTRIBUTING.md for reactive/VT/load-tests modules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,16 @@ mvn -pl order-service spring-boot:run -Dspring-boot.run.profiles=dev
 mvn -pl notification-stub spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
+Peer services for the servlet vs reactive vs Virtual Threads A/B load comparison (run one peer under load at a time — see [docs/ab-load-comparison.md](docs/ab-load-comparison.md)):
+
+```bash
+# WebFlux + R2DBC peer (port 8083)
+mvn -pl order-service-reactive spring-boot:run -Dspring-boot.run.profiles=dev
+
+# Virtual Threads + JDBC peer (port 8084)
+mvn -pl order-service-vt spring-boot:run -Dspring-boot.run.profiles=dev
+```
+
 Metrics: Prometheus http://localhost:9090, Grafana http://localhost:3000 — see [README Observability](README.md#observability).
 
 ### Centralized logging (OpenSearch)
@@ -107,7 +117,10 @@ Without `CODECOV_TOKEN`, the CI upload step fails (`fail_ci_if_error: true`).
 |--------|---------|
 | `outbox-events-contract` | Shared event DTOs and enums |
 | `order-service` | REST API, transactional outbox, Kafka publisher |
+| `order-service-reactive` | WebFlux + R2DBC peer (A/B load comparison, port 8083) |
+| `order-service-vt` | Virtual Threads + JDBC peer (A/B load comparison, port 8084) |
 | `notification-stub` | Demo downstream consumer |
+| `load-tests` | Gatling load tests for servlet / reactive / VT — see [docs/ab-load-comparison.md](docs/ab-load-comparison.md) |
 
 Package base: `com.kholodilin.outbox`.
 


### PR DESCRIPTION
## Summary

Updates `CONTRIBUTING.md` to reflect the peer modules added for the A/B load comparison:

- **Project structure** table now includes `order-service-reactive` (WebFlux + R2DBC, port 8083), `order-service-vt` (Virtual Threads + JDBC, port 8084), and `load-tests` (Gatling benchmarks for servlet / reactive / VT).
- **Run locally** now documents how to start the reactive and VT peers with profile `dev`, with a link to [docs/ab-load-comparison.md](docs/ab-load-comparison.md) for the sequential A/B guidance.

## Related issues

Fixes #33

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation update
- [ ] Refactoring / chore

## Affected modules

- [ ] `outbox-events-contract`
- [ ] `order-service`
- [ ] `order-service-reactive`
- [ ] `order-service-vt`
- [ ] `notification-stub`
- [ ] `docker-compose` / infrastructure
- [x] docs / CI / other

## Test plan

Docs-only change; no application code or build files touched, so `mvn clean verify` is not required per the issue's acceptance criteria.

- [ ] `mvn clean verify`
- [x] Manual testing (describe below)

**Manual steps (if any):**

```bash
# Reviewed rendered markdown; verified module names, ports, and links match
# docs/ab-load-comparison.md and the repository layout.
```

## Checklist

- [x] Code follows existing project conventions
- [ ] Tests added or updated where appropriate
- [x] Documentation updated (if user-facing behavior changed)
- [x] No secrets or environment-specific credentials committed
- [ ] Liquibase/schema changes documented (if applicable)
- [x] Codecov patch coverage check is green (or explained in PR description)
