### PR TITLE
Cover null correlationId branch in OrderTransactionService

### DIFF
--- a/order-service-vt/src/test/java/com/kholodilin/outbox/order/OrderTransactionServiceTest.java
+++ b/order-service-vt/src/test/java/com/kholodilin/outbox/order/OrderTransactionServiceTest.java
@@ -98,6 +98,31 @@ class OrderTransactionServiceTest {
         assertThat(outcome.response().eventId()).isEqualTo(200L);
         assertThat(outcome.response().status()).isEqualTo("ACCEPTED");
         verify(orderJdbcRepository).insertOrderItem(eq(100L), eq(42L), eq("sku-1"), eq(2), eq(BigDecimal.valueOf(5)), any(Instant.class));
+        verify(outboxAppend).header("correlationId", "corr-1");
+        verify(outboxAppend).append();
+    }
+
+    @Test
+    void createOrderOmitsCorrelationHeaderWhenAbsent() {
+        CreateOrderRequest request = new CreateOrderRequest(
+                42L,
+                List.of(new OrderItemRequest("sku-1", 2, BigDecimal.valueOf(5))),
+                null
+        );
+
+        when(orderJdbcRepository.insertOrder(eq(42L), eq(BigDecimal.valueOf(10)), any(Instant.class))).thenReturn(100L);
+        when(outboxEventFactory.buildOrderCreatedPayload(100L, request)).thenReturn("{\"orderId\":100}");
+        when(outboxEventFactory.eventType()).thenReturn("OrderCreated");
+        when(traceContextSupport.captureTraceParent()).thenReturn("00-trace");
+        stubIdempotencyExecuteAction();
+        stubOutboxAppend(200L);
+
+        OrderCreateOutcome outcome = service.createOrder(request, "idem-key");
+
+        assertThat(outcome.created()).isTrue();
+        verify(outboxAppend, never()).header(eq("correlationId"), anyString());
+        verify(outboxAppend).header("orderId", "100");
+        verify(outboxAppend).header("customerId", "42");
         verify(outboxAppend).append();
     }
 

--- a/order-service/src/test/java/com/kholodilin/outbox/order/OrderTransactionServiceTest.java
+++ b/order-service/src/test/java/com/kholodilin/outbox/order/OrderTransactionServiceTest.java
@@ -98,6 +98,31 @@ class OrderTransactionServiceTest {
         assertThat(outcome.response().eventId()).isEqualTo(200L);
         assertThat(outcome.response().status()).isEqualTo("ACCEPTED");
         verify(orderJdbcRepository).insertOrderItem(eq(100L), eq(42L), eq("sku-1"), eq(2), eq(BigDecimal.valueOf(5)), any(Instant.class));
+        verify(outboxAppend).header("correlationId", "corr-1");
+        verify(outboxAppend).append();
+    }
+
+    @Test
+    void createOrderOmitsCorrelationHeaderWhenAbsent() {
+        CreateOrderRequest request = new CreateOrderRequest(
+                42L,
+                List.of(new OrderItemRequest("sku-1", 2, BigDecimal.valueOf(5))),
+                null
+        );
+
+        when(orderJdbcRepository.insertOrder(eq(42L), eq(BigDecimal.valueOf(10)), any(Instant.class))).thenReturn(100L);
+        when(outboxEventFactory.buildOrderCreatedPayload(100L, request)).thenReturn("{\"orderId\":100}");
+        when(outboxEventFactory.eventType()).thenReturn("OrderCreated");
+        when(traceContextSupport.captureTraceParent()).thenReturn("00-trace");
+        stubIdempotencyExecuteAction();
+        stubOutboxAppend(200L);
+
+        OrderCreateOutcome outcome = service.createOrder(request, "idem-key");
+
+        assertThat(outcome.created()).isTrue();
+        verify(outboxAppend, never()).header(eq("correlationId"), anyString());
+        verify(outboxAppend).header("orderId", "100");
+        verify(outboxAppend).header("customerId", "42");
         verify(outboxAppend).append();
     }
 


### PR DESCRIPTION
## Summary

- Cover the `correlationId == null` branch when appending an outbox event so Codecov patch coverage is complete for servlet and VT.
- Assert the `correlationId` header is set when the request provides one.

## Related issues

Follow-up to #41 (Codecov reported 2 partial lines in `OrderTransactionService`).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation update
- [x] Refactoring / chore

## Affected modules

- [ ] `outbox-events-contract`
- [x] `order-service`
- [ ] `order-service-reactive`
- [x] `order-service-vt`
- [ ] `notification-stub`
- [ ] `docker-compose` / infrastructure
- [ ] docs / CI / other

## Test plan

- [x] `mvn -pl order-service,order-service-vt -am test -Dtest=OrderTransactionServiceTest`
- [ ] Manual testing (describe below)

**Manual steps (if any):**

```bash
# none — unit tests cover both header branches
```

## Checklist

- [x] Code follows existing project conventions
- [x] Tests added or updated where appropriate
- [x] Documentation updated (if user-facing behavior changed)
- [x] No secrets or environment-specific credentials committed
- [x] Liquibase/schema changes documented (if applicable)
- [ ] Codecov patch coverage check is green (or explained in PR description)