### PR TITLE
Bump spring-boot-idempotency-starter to 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Servlet (`order-service`) and Virtual Threads (`order-service-vt`) get that pipe
 | Starter | Version | Repository |
 |---------|---------|------------|
 | `spring-boot-outbox-starter` | `0.1.0` | [KHolodilin/spring-boot-outbox-starter](https://github.com/KHolodilin/spring-boot-outbox-starter) |
-| `spring-boot-idempotency-starter` | `0.3.0` | [KHolodilin/spring-boot-idempotency-starter](https://github.com/KHolodilin/spring-boot-idempotency-starter) |
+| `spring-boot-idempotency-starter` | `0.3.1` | [KHolodilin/spring-boot-idempotency-starter](https://github.com/KHolodilin/spring-boot-idempotency-starter) |
 
 ## 🔄 How it works
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <testcontainers.version>1.21.4</testcontainers.version>
         <jacoco.version>0.8.12</jacoco.version>
         <logstash-logback-encoder.version>8.0</logstash-logback-encoder.version>
-        <idempotency-starter.version>0.3.0</idempotency-starter.version>
+        <idempotency-starter.version>0.3.1</idempotency-starter.version>
         <outbox-starter.version>0.1.0</outbox-starter.version>
         <mockito.agent.argLine>-javaagent:@{org.mockito:mockito-core:jar}</mockito.agent.argLine>
     </properties>


### PR DESCRIPTION
## Summary

- Bump `${idempotency-starter.version}` `0.3.0` → `0.3.1` (parent `dependencyManagement`; used by `order-service` and `order-service-vt`).
- Update the README starter table to match.
- `0.3.1` is a patch (Spring Boot 4.1.1 / plugin bumps); no API or schema changes. Reactive does not use this starter.

## Related issues

Follow-up to #41.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation update
- [x] Refactoring / chore

## Affected modules

- [ ] `outbox-events-contract`
- [x] `order-service`
- [ ] `order-service-reactive`
- [x] `order-service-vt`
- [ ] `notification-stub`
- [ ] `docker-compose` / infrastructure
- [x] docs / CI / other

## Test plan

- [x] `mvn -U -pl order-service,order-service-vt -am clean verify`
- [ ] Manual testing (describe below)

**Manual steps (if any):**

```bash
# none — unit + Testcontainers IT
```

## Checklist

- [x] Code follows existing project conventions
- [x] Tests added or updated where appropriate
- [x] Documentation updated (if user-facing behavior changed)
- [x] No secrets or environment-specific credentials committed
- [x] Liquibase/schema changes documented (if applicable)
- [ ] Codecov patch coverage check is green (or explained in PR description)