### PR TITLE
test: add reactive config unit tests

### DIFF
--- a/order-service-reactive/src/test/java/com/kholodilin/outbox/config/KafkaProducerConfigTest.java
+++ b/order-service-reactive/src/test/java/com/kholodilin/outbox/config/KafkaProducerConfigTest.java
@@ -1,0 +1,33 @@
+package com.kholodilin.outbox.config;
+
+import tools.jackson.databind.json.JsonMapper;
+import com.kholodilin.outbox.events.EventEnvelope;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaProducerConfigTest {
+
+    @Test
+    void serializesInstantAsIso8601() throws Exception {
+        JsonMapper mapper = KafkaProducerConfig.kafkaObjectMapper();
+        EventEnvelope envelope = new EventEnvelope(
+                1L,
+                10L,
+                20L,
+                "OrderCreated",
+                Map.of("orderId", 10),
+                null,
+                Instant.parse("2026-07-12T10:15:30Z"),
+                null
+        );
+
+        String json = mapper.writeValueAsString(envelope);
+
+        assertThat(json).contains("2026-07-12T10:15:30Z");
+        assertThat(json).doesNotContain("1752305730");
+    }
+}

--- a/order-service-reactive/src/test/java/com/kholodilin/outbox/config/LoggingPropertiesTest.java
+++ b/order-service-reactive/src/test/java/com/kholodilin/outbox/config/LoggingPropertiesTest.java
@@ -1,0 +1,16 @@
+package com.kholodilin.outbox.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoggingPropertiesTest {
+
+    @Test
+    void builderProvidesJsonDefaults() {
+        LoggingProperties properties = LoggingProperties.builder().build();
+
+        assertThat(properties.getJson().isEnabled()).isTrue();
+        assertThat(properties.getJson().getPath()).isEqualTo("./logs");
+    }
+}


### PR DESCRIPTION
## Summary

Adds missing configuration tests for the reactive order service to maintain test parity with the servlet implementation.

Adds coverage for:
- Default JSON logging configuration in `LoggingProperties`
- ISO-8601 `Instant` serialization in `KafkaProducerConfig`

## Related issues

Fixes #44

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation update
- [x] Refactoring / chore

## Affected modules

- [ ] `outbox-events-contract`
- [ ] `order-service`
- [x] `order-service-reactive`
- [ ] `order-service-vt`
- [ ] `notification-stub`
- [ ] `docker-compose` / infrastructure
- [ ] docs / CI / other

## Test plan

- [x] `mvn clean verify`
- [ ] Manual testing (describe below)

**Manual steps (if any):**

N/A

## Checklist

- [x] Code follows existing project conventions
- [x] Tests added or updated where appropriate
- [ ] Documentation updated (if user-facing behavior changed)
- [x] No secrets or environment-specific credentials committed
- [ ] Liquibase/schema changes documented (if applicable)
- [ ] Codecov patch coverage check is green (or explained in PR description)