### PR TITLE
Upgrade idempotency starter to 0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Servlet (`order-service`) and Virtual Threads (`order-service-vt`) get that pipe
 | Starter | Version | Repository |
 |---------|---------|------------|
 | `spring-boot-outbox-starter` | `0.1.0` | [KHolodilin/spring-boot-outbox-starter](https://github.com/KHolodilin/spring-boot-outbox-starter) |
-| `spring-boot-idempotency-starter` | `0.3.1` | [KHolodilin/spring-boot-idempotency-starter](https://github.com/KHolodilin/spring-boot-idempotency-starter) |
+| `spring-boot-idempotency-starter` | `0.3.2` | [KHolodilin/spring-boot-idempotency-starter](https://github.com/KHolodilin/spring-boot-idempotency-starter) |
 
 ## 🔄 How it works
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <testcontainers.version>1.21.4</testcontainers.version>
         <jacoco.version>0.8.12</jacoco.version>
         <logstash-logback-encoder.version>8.0</logstash-logback-encoder.version>
-        <idempotency-starter.version>0.3.1</idempotency-starter.version>
+        <idempotency-starter.version>0.3.2</idempotency-starter.version>
         <outbox-starter.version>0.1.0</outbox-starter.version>
         <mockito.agent.argLine>-javaagent:@{org.mockito:mockito-core:jar}</mockito.agent.argLine>
     </properties>


### PR DESCRIPTION
## Summary

Upgrade `spring-boot-idempotency-starter` from `0.3.1` to `0.3.2` and update the README dependency version.

## Related issues

Closes #46

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation update
- [x] Refactoring / chore

## Affected modules

- [ ] `outbox-events-contract`
- [x] `order-service`
- [ ] `order-service-reactive`
- [x] `order-service-vt`
- [ ] `notification-stub`
- [ ] `docker-compose` / infrastructure
- [x] docs / CI / other

## Test plan

- [x] `mvn clean verify`
- [ ] Manual testing (describe below)

**Manual steps (if any):**

```bash
mvn -U -pl order-service,order-service-vt -am clean verify