### PR TITLE
Add Docker demo stacks and GHCR release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
 
           ## Quick start
 
-          Download one compose file, then start it (do not run two flavors at once — they share ports 5432, 9092, 8080, and 8081).
+          Download one compose file (or all three — host ports do not overlap). Servlet order API is \`:8090\`.
 
           **PowerShell (servlet):**
 
@@ -92,16 +92,16 @@ jobs:
           docker compose -f compose.yml up -d
           \`\`\`
 
-          | Stack | Asset |
-          |-------|--------|
-          | Servlet + JDBC | \`compose.servlet.yml\` |
-          | WebFlux + R2DBC | \`compose.reactive.yml\` |
-          | Virtual Threads + JDBC | \`compose.vt.yml\` |
+          | Stack | Asset | Order | Grafana |
+          |-------|--------|-------|---------|
+          | Servlet + JDBC | \`compose.servlet.yml\` | \`:8090\` | \`:3000\` |
+          | WebFlux + R2DBC | \`compose.reactive.yml\` | \`:8092\` | \`:3001\` |
+          | Virtual Threads + JDBC | \`compose.vt.yml\` | \`:8094\` | \`:3002\` |
 
-          Create an order:
+          Create an order (servlet):
 
           \`\`\`bash
-          curl -X POST http://localhost:8080/api/v1/orders \\
+          curl -X POST http://localhost:8090/api/v1/orders \\
             -H "Content-Type: application/json" \\
             -H "Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000" \\
             -d '{"customerId":42,"items":[{"productId":"sku-1","quantity":2,"price":10.50}],"correlationId":"demo"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_PREFIX: ghcr.io/kholodilin/spring-transactional-outbox-kafka
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: temurin
+          cache: maven
+
+      - name: Package
+        run: mvn -B -DskipTests package
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push images
+        run: |
+          build_push() {
+            local module="$1"
+            local image="${IMAGE_PREFIX}/${module}"
+            docker build \
+              --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+              --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+              --label "org.opencontainers.image.version=${VERSION}" \
+              -t "${image}:${VERSION}" \
+              -t "${image}:latest" \
+              "${module}"
+            docker push "${image}:${VERSION}"
+            docker push "${image}:latest"
+          }
+          build_push order-service
+          build_push order-service-reactive
+          build_push order-service-vt
+          build_push notification-stub
+
+      - name: Pin compose image tags
+        run: |
+          mkdir -p dist
+          for f in docker/compose.servlet.yml docker/compose.reactive.yml docker/compose.vt.yml; do
+            sed "s/\${APP_VERSION:-latest}/${VERSION}/g" "$f" > "dist/$(basename "$f")"
+          done
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > dist/release-notes.md <<EOF
+          Docker demo stacks for the transactional outbox example. Java and Maven are not required.
+
+          ## Quick start
+
+          Download one compose file, then start it (do not run two flavors at once — they share ports 5432, 9092, 8080, and 8081).
+
+          **PowerShell (servlet):**
+
+          \`\`\`powershell
+          Invoke-WebRequest -Uri https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/compose.servlet.yml -OutFile compose.yml
+          docker compose -f compose.yml up -d
+          \`\`\`
+
+          **bash (servlet):**
+
+          \`\`\`bash
+          curl -fsSL -o compose.yml https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/compose.servlet.yml
+          docker compose -f compose.yml up -d
+          \`\`\`
+
+          | Stack | Asset |
+          |-------|--------|
+          | Servlet + JDBC | \`compose.servlet.yml\` |
+          | WebFlux + R2DBC | \`compose.reactive.yml\` |
+          | Virtual Threads + JDBC | \`compose.vt.yml\` |
+
+          Create an order:
+
+          \`\`\`bash
+          curl -X POST http://localhost:8080/api/v1/orders \\
+            -H "Content-Type: application/json" \\
+            -H "Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000" \\
+            -d '{"customerId":42,"items":[{"productId":"sku-1","quantity":2,"price":10.50}],"correlationId":"demo"}'
+          \`\`\`
+
+          Images: \`ghcr.io/kholodilin/spring-transactional-outbox-kafka/*:${VERSION}\`.
+
+          Grafana / Prometheus / OpenSearch need a git clone and \`--profile observability\` (bind-mounts \`monitoring/\`).
+          EOF
+          gh release create "${GITHUB_REF_NAME}" \
+            dist/compose.servlet.yml \
+            dist/compose.reactive.yml \
+            dist/compose.vt.yml \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file dist/release-notes.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,9 +126,9 @@ Without `CODECOV_TOKEN`, the CI upload step fails (`fail_ci_if_error: true`).
 | `order-service-vt` | Virtual Threads + JDBC peer (A/B load comparison, port 8084) |
 | `notification-stub` | Demo downstream consumer |
 | `load-tests` | Gatling load tests for servlet / reactive / VT — see [docs/ab-load-comparison.md](docs/ab-load-comparison.md) |
-| `docker/compose.servlet.yml` | Docker demo stack (servlet). Same ports as Maven servlet (`:8080` / `:8081`) |
-| `docker/compose.reactive.yml` | Docker demo stack (WebFlux). Order service on `:8080` |
-| `docker/compose.vt.yml` | Docker demo stack (virtual threads). Order service on `:8080` |
+| `docker/compose.servlet.yml` | Docker demo stack (servlet). Order `:8090`, stub `:8091`, Grafana `:3000` |
+| `docker/compose.reactive.yml` | Docker demo stack (WebFlux). Order `:8092`, stub `:8093`, Grafana `:3001` |
+| `docker/compose.vt.yml` | Docker demo stack (virtual threads). Order `:8094`, stub `:8095`, Grafana `:3002` |
 
 Package base: `com.kholodilin.outbox`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,16 @@ Thank you for your interest in contributing to **spring-transactional-outbox-kaf
 
 * Java 21
 * Maven 3.9+
-* Docker (for PostgreSQL, Kafka, Prometheus, Grafana, OpenSearch, and integration tests)
+* Docker (for PostgreSQL, Kafka, optional observability, and integration tests)
 
 ### Build and test
 
 ```bash
 # Start infrastructure
 docker compose up -d
+
+# Metrics / logs / traces (Grafana, Prometheus, Tempo, OpenSearch)
+docker compose --profile observability up -d
 
 # Full build with tests
 mvn clean verify
@@ -46,11 +49,11 @@ mvn -pl order-service-reactive spring-boot:run -Dspring-boot.run.profiles=dev
 mvn -pl order-service-vt spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
-Metrics: Prometheus http://localhost:9090, Grafana http://localhost:3000 — see [README Observability](README.md#observability).
+Metrics: `docker compose --profile observability up -d`, then Prometheus http://localhost:9090, Grafana http://localhost:3000 — see [README Observability](README.md#observability).
 
 ### Centralized logging (OpenSearch)
 
-1. `docker compose up -d` — starts OpenSearch (`:9200`), Dashboards (`:5601`), Fluent Bit.
+1. `docker compose --profile observability up -d` — starts OpenSearch (`:9200`), Dashboards (`:5601`), Fluent Bit.
 2. Apply index template: see [docs/logging.md](docs/logging.md).
 3. Run services with profile `dev` — JSON logs land in `./logs/<service>/app.json`.
 4. Import saved objects from `monitoring/opensearch-dashboards/saved-objects.ndjson`.
@@ -65,7 +68,7 @@ Environment variables:
 
 ### Distributed tracing (local)
 
-1. `docker compose up -d` — starts Tempo (OTLP HTTP `:4318`, query `:3200`).
+1. `docker compose --profile observability up -d` — starts Tempo (OTLP HTTP `:4318`, query `:3200`).
 2. Run services with profile `dev` (100% sampling, OTLP to `localhost:4318`).
 3. Open Grafana → **Distributed Tracing** dashboard after creating an order.
 4. Logs include `traceId` and `spanId` via `logback-spring.xml`.
@@ -91,6 +94,8 @@ notification-stub/target/site/jacoco/jacoco.xml
 ```
 
 CI uploads all module reports to Codecov (merged on the Codecov side).
+
+Pushing a tag `v*` (for example `v1.2.0`) runs [Release](.github/workflows/release.yml): Maven package, four images to GHCR, and a GitHub Release with `compose.servlet.yml`, `compose.reactive.yml`, and `compose.vt.yml`.
 
 ## Continuous integration and Codecov
 
@@ -121,6 +126,9 @@ Without `CODECOV_TOKEN`, the CI upload step fails (`fail_ci_if_error: true`).
 | `order-service-vt` | Virtual Threads + JDBC peer (A/B load comparison, port 8084) |
 | `notification-stub` | Demo downstream consumer |
 | `load-tests` | Gatling load tests for servlet / reactive / VT — see [docs/ab-load-comparison.md](docs/ab-load-comparison.md) |
+| `docker/compose.servlet.yml` | Docker demo stack (servlet). Same ports as Maven servlet (`:8080` / `:8081`) |
+| `docker/compose.reactive.yml` | Docker demo stack (WebFlux). Order service on `:8080` |
+| `docker/compose.vt.yml` | Docker demo stack (virtual threads). Order service on `:8080` |
 
 Package base: `com.kholodilin.outbox`.
 

--- a/README.md
+++ b/README.md
@@ -289,13 +289,13 @@ After `docker compose --profile observability up -d` (clone) or the same profile
 
 You only need **Docker**. Java and Maven are not required.
 
-Pick one stack — servlet, WebFlux, or Virtual Threads. Do not run two flavors at the same time; they all use ports `5432`, `9092`, `8080`, and `8081`.
+Pick a stack — servlet, WebFlux, or Virtual Threads. Host ports do not overlap; all three can run at once.
 
-| Stack | Compose asset | What you get |
-|-------|---------------|--------------|
-| Servlet + JDBC | `compose.servlet.yml` | `order-service` + `notification-stub` |
-| WebFlux + R2DBC | `compose.reactive.yml` | `order-service-reactive` + `notification-stub` |
-| Virtual Threads + JDBC | `compose.vt.yml` | `order-service-vt` + `notification-stub` |
+| Stack | Compose asset | Order | Stub | Grafana |
+|-------|---------------|-------|------|---------|
+| Servlet + JDBC | `compose.servlet.yml` | http://localhost:8090 | :8091 | :3000 |
+| WebFlux + R2DBC | `compose.reactive.yml` | http://localhost:8092 | :8093 | :3001 |
+| Virtual Threads + JDBC | `compose.vt.yml` | http://localhost:8094 | :8095 | :3002 |
 
 ### 🐳 1. Download a compose file and start
 
@@ -321,14 +321,14 @@ From a clone, the same files live in `docker/`:
 docker compose -f docker/compose.servlet.yml up -d
 ```
 
-Order Service: http://localhost:8080 — Notification Stub: http://localhost:8081
+Order Service: http://localhost:8090 — Notification Stub: http://localhost:8091
 
 ### 🛒 2. Create an order
 
 Send a request with a unique `Idempotency-Key`:
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/orders \
+curl -X POST http://localhost:8090/api/v1/orders \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000" \
   -d '{
@@ -359,7 +359,7 @@ After the commit, the outbox event ID is placed into the Memory Queue, published
 Repeat the same request with the same `Idempotency-Key` and payload:
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/orders \
+curl -X POST http://localhost:8090/api/v1/orders \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000" \
   -d '{
@@ -393,14 +393,14 @@ cd spring-transactional-outbox-kafka
 docker compose -f docker/compose.servlet.yml --profile observability up -d
 ```
 
-The same `--profile observability` flag works on `compose.reactive.yml` and `compose.vt.yml`.
+The same `--profile observability` flag works on `compose.reactive.yml` (Grafana :3001) and `compose.vt.yml` (Grafana :3002). Each stack provisions only its Orders Technical dashboard.
 
-Open the local observability services:
+Open the local observability services (servlet example):
 
 | Service | URL | What to check |
 |---------|-----|---------------|
-| Grafana | http://localhost:3000 | Queue size, publishing latency, retries, recovery and JVM metrics |
-| Prometheus | http://localhost:9090 | Application and PostgreSQL metrics |
+| Grafana | http://localhost:3000 | **Orders Technical** (servlet). Reactive → :3001, VT → :3002 |
+| Prometheus | http://localhost:9100 | Application and PostgreSQL metrics |
 | OpenSearch Dashboards | http://localhost:5601 | Structured application logs |
 | Grafana Tempo | http://localhost:3200 | Distributed trace storage |
 | OpenSearch | http://localhost:9200 | Indexed JSON logs |
@@ -415,8 +415,8 @@ Password: admin
 You can also verify the application metrics directly:
 
 ```bash
-curl http://localhost:8080/actuator/prometheus
-curl http://localhost:8081/actuator/prometheus
+curl http://localhost:8090/actuator/prometheus
+curl http://localhost:8091/actuator/prometheus
 ```
 
 ### 🛑 5. Stop the environment
@@ -480,13 +480,13 @@ mvn -pl load-tests gatling:test \
 
 Peer services for sequential Gatling A/B (one under load at a time). See [docs/ab-load-comparison.md](docs/ab-load-comparison.md).
 
-From source, peers use different ports. Docker flavors all expose the order service on `:8080` — run one compose file at a time.
+Maven peers use `:8080` / `:8083` / `:8084`. Docker flavors can run together:
 
-| Module | Maven port | Docker flavor | DB |
-|--------|------------|---------------|-----|
-| `order-service` | 8080 | `docker/compose.servlet.yml` | `outbox` |
-| `order-service-reactive` | 8083 | `docker/compose.reactive.yml` | `outbox_reactive` |
-| `order-service-vt` | 8084 | `docker/compose.vt.yml` | `outbox_vt` |
+| Module | Maven | Docker | Grafana |
+|--------|-------|--------|---------|
+| `order-service` | 8080 | 8090 (`compose.servlet.yml`) | 3000 |
+| `order-service-reactive` | 8083 | 8092 (`compose.reactive.yml`) | 3001 |
+| `order-service-vt` | 8084 | 8094 (`compose.vt.yml`) | 3002 |
 
 ```bash
 mvn -pl load-tests gatling:test \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Transactional Outbox Pattern with Kafka and PostgreSQL
 
 [![CI](https://github.com/KHolodilin/spring-transactional-outbox-kafka/actions/workflows/ci.yml/badge.svg)](https://github.com/KHolodilin/spring-transactional-outbox-kafka/actions/workflows/ci.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/KHolodilin/spring-transactional-outbox-kafka)](https://github.com/KHolodilin/spring-transactional-outbox-kafka/releases/latest)
 [![codecov](https://codecov.io/gh/KHolodilin/spring-transactional-outbox-kafka/graph/badge.svg)](https://codecov.io/gh/KHolodilin/spring-transactional-outbox-kafka)
 [![Java](https://img.shields.io/badge/Java-21-orange?logo=openjdk)](https://openjdk.org/)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1-brightgreen?logo=springboot)](https://spring.io/projects/spring-boot)
@@ -269,7 +270,7 @@ Distributed tracing helps you:
 
 ### 🌐 Local Services
 
-After starting the Docker Compose infrastructure, the following services are available:
+After `docker compose --profile observability up -d` (clone) or the same profile on a flavor file, the following services are available:
 
 | Service | URL | Purpose |
 |---------|-----|---------|
@@ -286,64 +287,43 @@ After starting the Docker Compose infrastructure, the following services are ava
 
 ## 🚀 Quick Start
 
-Run the complete Transactional Outbox example locally and publish your first event in a few minutes.
+You only need **Docker**. Java and Maven are not required.
 
-### 🐳 1. Start the infrastructure
+Pick one stack — servlet, WebFlux, or Virtual Threads. Do not run two flavors at the same time; they all use ports `5432`, `9092`, `8080`, and `8081`.
 
-```bash
-docker compose up -d
+| Stack | Compose asset | What you get |
+|-------|---------------|--------------|
+| Servlet + JDBC | `compose.servlet.yml` | `order-service` + `notification-stub` |
+| WebFlux + R2DBC | `compose.reactive.yml` | `order-service-reactive` + `notification-stub` |
+| Virtual Threads + JDBC | `compose.vt.yml` | `order-service-vt` + `notification-stub` |
+
+### 🐳 1. Download a compose file and start
+
+PowerShell (servlet):
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/KHolodilin/spring-transactional-outbox-kafka/releases/latest/download/compose.servlet.yml -OutFile compose.yml
+docker compose -f compose.yml up -d
 ```
 
-Docker Compose starts the required infrastructure:
-
-- PostgreSQL
-- Kafka
-- Prometheus
-- Grafana
-- Grafana Tempo
-- OpenSearch
-- OpenSearch Dashboards
-- Fluent Bit
-- PostgreSQL Exporter
-
-Check that all containers are running:
+bash (servlet):
 
 ```bash
-docker compose ps
+curl -fsSL -o compose.yml https://github.com/KHolodilin/spring-transactional-outbox-kafka/releases/latest/download/compose.servlet.yml
+docker compose -f compose.yml up -d
 ```
 
-### 🔨 2. Build the project
+Replace `compose.servlet.yml` with `compose.reactive.yml` or `compose.vt.yml` for the other stacks.
+
+From a clone, the same files live in `docker/`:
 
 ```bash
-mvn clean verify
+docker compose -f docker/compose.servlet.yml up -d
 ```
 
-This command compiles all modules and runs the automated test suite.
+Order Service: http://localhost:8080 — Notification Stub: http://localhost:8081
 
-### ▶️ 3. Start the application services
-
-Run the Order Service:
-
-```bash
-mvn -pl order-service spring-boot:run \
-  -Dspring-boot.run.profiles=dev
-```
-
-In a separate terminal, run the Notification Stub:
-
-```bash
-mvn -pl notification-stub spring-boot:run \
-  -Dspring-boot.run.profiles=dev
-```
-
-The services will be available at:
-
-| Service | URL |
-|---------|-----|
-| Order Service | http://localhost:8080 |
-| Notification Stub | http://localhost:8081 |
-
-### 🛒 4. Create an order
+### 🛒 2. Create an order
 
 Send a request with a unique `Idempotency-Key`:
 
@@ -374,7 +354,7 @@ All three records are committed in the same PostgreSQL transaction.
 
 After the commit, the outbox event ID is placed into the Memory Queue, published to Kafka, and consumed by the Notification Stub.
 
-### ♻️ 5. Verify idempotency
+### ♻️ 3. Verify idempotency
 
 Repeat the same request with the same `Idempotency-Key` and payload:
 
@@ -403,7 +383,17 @@ Using the same key with a different request payload returns:
 HTTP 409 Conflict
 ```
 
-### 🧭 6. Explore metrics, logs, and traces
+### 🧭 4. Explore metrics, logs, and traces
+
+Grafana, Prometheus, Tempo, and OpenSearch bind-mount files from `monitoring/`, so this step needs a **git clone**.
+
+```bash
+git clone https://github.com/KHolodilin/spring-transactional-outbox-kafka.git
+cd spring-transactional-outbox-kafka
+docker compose -f docker/compose.servlet.yml --profile observability up -d
+```
+
+The same `--profile observability` flag works on `compose.reactive.yml` and `compose.vt.yml`.
 
 Open the local observability services:
 
@@ -429,19 +419,37 @@ curl http://localhost:8080/actuator/prometheus
 curl http://localhost:8081/actuator/prometheus
 ```
 
-### 🛑 Stop the environment
-
-Stop the application services with `Ctrl+C`, then shut down the Docker Compose infrastructure:
+### 🛑 5. Stop the environment
 
 ```bash
-docker compose down
+docker compose -f compose.yml down
+```
+
+From a clone:
+
+```bash
+docker compose -f docker/compose.servlet.yml --profile observability down
 ```
 
 To remove containers together with local volumes and stored data:
 
 ```bash
-docker compose down -v
+docker compose -f docker/compose.servlet.yml --profile observability down -v
 ```
+
+### 🛠️ Run from source (Java 21 + Maven)
+
+Root `docker-compose.yml` starts Postgres and Kafka for host processes. Observability is opt-in:
+
+```bash
+docker compose up -d
+docker compose --profile observability up -d
+mvn clean verify
+mvn -pl order-service spring-boot:run -Dspring-boot.run.profiles=dev
+mvn -pl notification-stub spring-boot:run -Dspring-boot.run.profiles=dev
+```
+
+Peer services stay on `:8083` (reactive) and `:8084` (virtual threads). See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## ⚡ Load Testing
 
@@ -472,11 +480,13 @@ mvn -pl load-tests gatling:test \
 
 Peer services for sequential Gatling A/B (one under load at a time). See [docs/ab-load-comparison.md](docs/ab-load-comparison.md).
 
-| Module | Port | DB |
-|--------|------|-----|
-| `order-service` | 8080 | `outbox` |
-| `order-service-reactive` | 8083 | `outbox_reactive` |
-| `order-service-vt` | 8084 | `outbox_vt` |
+From source, peers use different ports. Docker flavors all expose the order service on `:8080` — run one compose file at a time.
+
+| Module | Maven port | Docker flavor | DB |
+|--------|------------|---------------|-----|
+| `order-service` | 8080 | `docker/compose.servlet.yml` | `outbox` |
+| `order-service-reactive` | 8083 | `docker/compose.reactive.yml` | `outbox_reactive` |
+| `order-service-vt` | 8084 | `docker/compose.vt.yml` | `outbox_vt` |
 
 ```bash
 mvn -pl load-tests gatling:test \

--- a/docker/compose.reactive.yml
+++ b/docker/compose.reactive.yml
@@ -1,19 +1,19 @@
-# Maven / contributor infra. Apps run on the host (mvn spring-boot:run).
+# WebFlux stack: Postgres + Kafka + order-service-reactive + notification-stub.
 # Observability: docker compose --profile observability up -d
-# Keep Kafka listeners in sync with docker/compose.servlet.yml, compose.reactive.yml, compose.vt.yml.
+# Keep Kafka listeners in sync with compose.servlet.yml, compose.vt.yml, and ../docker-compose.yml.
+name: outbox-reactive
+
 services:
   postgres:
     image: postgres:18.4
     environment:
-      POSTGRES_DB: outbox
+      POSTGRES_DB: outbox_reactive
       POSTGRES_USER: outbox
       POSTGRES_PASSWORD: outbox
     ports:
       - "5432:5432"
-    volumes:
-      - ./docker/postgres/init-databases.sql:/docker-entrypoint-initdb.d/01-init-databases.sql:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U outbox -d outbox"]
+      test: ["CMD-SHELL", "pg_isready -U outbox -d outbox_reactive"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -62,11 +62,55 @@ services:
           --replication-factor 1
         echo "Topic orders.events is ready (10 partitions)"
 
+  order-service:
+    image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/order-service-reactive:${APP_VERSION:-latest}
+    ports:
+      - "8080:8080"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_NAME: outbox_reactive
+      DB_USER: outbox
+      DB_PASSWORD: outbox
+      KAFKA_BOOTSTRAP: kafka:29092
+      SERVER_PORT: "8080"
+      LOG_JSON_PATH: /var/log/app
+      DEPLOYMENT_ENV: local
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+    volumes:
+      - ../logs:/var/log/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+
+  notification-stub:
+    image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/notification-stub:${APP_VERSION:-latest}
+    ports:
+      - "8081:8081"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      KAFKA_BOOTSTRAP: kafka:29092
+      LOG_JSON_PATH: /var/log/app
+      DEPLOYMENT_ENV: local
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+    volumes:
+      - ../logs:/var/log/app
+    depends_on:
+      kafka-init:
+        condition: service_completed_successfully
+      order-service:
+        condition: service_started
+
   postgres-exporter:
     profiles: ["observability"]
     image: prometheuscommunity/postgres-exporter:v0.17.1
     environment:
-      DATA_SOURCE_NAME: "postgresql://outbox:outbox@postgres:5432/outbox?sslmode=disable"
+      DATA_SOURCE_NAME: "postgresql://outbox:outbox@postgres:5432/outbox_reactive?sslmode=disable"
     ports:
       - "9187:9187"
     depends_on:
@@ -81,7 +125,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
@@ -98,7 +142,7 @@ services:
       GF_RENDERING_SERVER_URL: http://grafana-image-renderer:8081/render
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/
     volumes:
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
       - tempo
@@ -118,7 +162,7 @@ services:
       - "3200:3200"
       - "4318:4318"
     volumes:
-      - ./monitoring/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - ../monitoring/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
 
   opensearch:
     profiles: ["observability"]
@@ -149,7 +193,7 @@ services:
     image: curlimages/curl:8.12.1
     restart: "no"
     volumes:
-      - ./monitoring/opensearch/index-template.json:/index-template.json:ro
+      - ../monitoring/opensearch/index-template.json:/index-template.json:ro
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -167,7 +211,7 @@ services:
     image: curlimages/curl:8.12.1
     restart: "no"
     volumes:
-      - ./monitoring/opensearch-dashboards/saved-objects.ndjson:/saved-objects.ndjson:ro
+      - ../monitoring/opensearch-dashboards/saved-objects.ndjson:/saved-objects.ndjson:ro
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -185,9 +229,9 @@ services:
     profiles: ["observability"]
     image: fluent/fluent-bit:3.2.10
     volumes:
-      - ./logs:/var/log/app:ro
-      - ./monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
-      - ./monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
+      - ../logs:/var/log/app:ro
+      - ../monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
+      - ../monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
     depends_on:
       - opensearch
 

--- a/docker/compose.reactive.yml
+++ b/docker/compose.reactive.yml
@@ -1,6 +1,5 @@
-# WebFlux stack: Postgres + Kafka + order-service-reactive + notification-stub.
-# Observability: docker compose --profile observability up -d
-# Keep Kafka listeners in sync with compose.servlet.yml, compose.vt.yml, and ../docker-compose.yml.
+# WebFlux stack. Host ports do not overlap with compose.servlet.yml / compose.vt.yml.
+# Order 8092, stub 8093, Grafana 3001.
 name: outbox-reactive
 
 services:
@@ -11,7 +10,7 @@ services:
       POSTGRES_USER: outbox
       POSTGRES_PASSWORD: outbox
     ports:
-      - "5432:5432"
+      - "5433:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U outbox -d outbox_reactive"]
       interval: 5s
@@ -21,12 +20,12 @@ services:
   kafka:
     image: apache/kafka:3.9.1
     ports:
-      - "9092:9092"
+      - "19093:9092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:19093
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
@@ -50,12 +49,12 @@ services:
       - |
         echo "Waiting for Kafka..."
         for i in $$(seq 1 30); do
-          if /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1; then
+          if /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:29092 --list >/dev/null 2>&1; then
             break
           fi
           sleep 2
         done
-        /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 \
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:29092 \
           --create --if-not-exists \
           --topic orders.events \
           --partitions 10 \
@@ -65,7 +64,7 @@ services:
   order-service:
     image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/order-service-reactive:${APP_VERSION:-latest}
     ports:
-      - "8080:8080"
+      - "8092:8080"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -76,11 +75,12 @@ services:
       DB_PASSWORD: outbox
       KAFKA_BOOTSTRAP: kafka:29092
       SERVER_PORT: "8080"
+      SPRING_PROFILES_ACTIVE: dev
       LOG_JSON_PATH: /var/log/app
       DEPLOYMENT_ENV: local
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318/v1/traces
     volumes:
-      - ../logs:/var/log/app
+      - ../logs/reactive:/var/log/app
     depends_on:
       postgres:
         condition: service_healthy
@@ -90,16 +90,17 @@ services:
   notification-stub:
     image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/notification-stub:${APP_VERSION:-latest}
     ports:
-      - "8081:8081"
+      - "8093:8081"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
       KAFKA_BOOTSTRAP: kafka:29092
+      SPRING_PROFILES_ACTIVE: dev
       LOG_JSON_PATH: /var/log/app
       DEPLOYMENT_ENV: local
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318/v1/traces
     volumes:
-      - ../logs:/var/log/app
+      - ../logs/reactive:/var/log/app
     depends_on:
       kafka-init:
         condition: service_completed_successfully
@@ -112,7 +113,7 @@ services:
     environment:
       DATA_SOURCE_NAME: "postgresql://outbox:outbox@postgres:5432/outbox_reactive?sslmode=disable"
     ports:
-      - "9187:9187"
+      - "9188:9187"
     depends_on:
       postgres:
         condition: service_healthy
@@ -121,11 +122,9 @@ services:
     profiles: ["observability"]
     image: prom/prometheus:v3.5.0
     ports:
-      - "9090:9090"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - "9101:9090"
     volumes:
-      - ../monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../monitoring/prometheus/prometheus-reactive.yml:/etc/prometheus/prometheus.yml:ro
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
@@ -134,7 +133,7 @@ services:
     profiles: ["observability"]
     image: grafana/grafana:12.3.3
     ports:
-      - "3000:3000"
+      - "3001:3000"
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
@@ -142,7 +141,12 @@ services:
       GF_RENDERING_SERVER_URL: http://grafana-image-renderer:8081/render
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/
     volumes:
-      - ../monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ../monitoring/grafana/provisioning/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ../monitoring/grafana/provisioning/dashboards/orders-technical-reactive-dashboard.json:/etc/grafana/provisioning/dashboards/orders-technical.json:ro
+      - ../monitoring/grafana/provisioning/dashboards/postgres-dashboard.json:/etc/grafana/provisioning/dashboards/postgres.json:ro
+      - ../monitoring/grafana/provisioning/dashboards/notification-stub-dashboard.json:/etc/grafana/provisioning/dashboards/notification-stub.json:ro
+      - ../monitoring/grafana/provisioning/dashboards/tracing-dashboard.json:/etc/grafana/provisioning/dashboards/tracing.json:ro
     depends_on:
       - prometheus
       - tempo
@@ -152,15 +156,15 @@ services:
     profiles: ["observability"]
     image: grafana/grafana-image-renderer:3.12.2
     ports:
-      - "8082:8081"
+      - "3192:8081"
 
   tempo:
     profiles: ["observability"]
     image: grafana/tempo:2.8.0
     command: ["-config.file=/etc/tempo/tempo.yaml"]
     ports:
-      - "3200:3200"
-      - "4318:4318"
+      - "3201:3200"
+      - "4319:4318"
     volumes:
       - ../monitoring/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
 
@@ -173,7 +177,7 @@ services:
       OPENSEARCH_JAVA_OPTS: -Xms512m -Xmx512m
       DISABLE_INSTALL_DEMO_CONFIG: "true"
     ports:
-      - "9200:9200"
+      - "9201:9200"
     volumes:
       - opensearch-data:/usr/share/opensearch/data
 
@@ -181,7 +185,7 @@ services:
     profiles: ["observability"]
     image: opensearchproject/opensearch-dashboards:2.19.2
     ports:
-      - "5601:5601"
+      - "5602:5601"
     environment:
       OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
       DISABLE_SECURITY_DASHBOARDS_PLUGIN: "true"
@@ -229,7 +233,7 @@ services:
     profiles: ["observability"]
     image: fluent/fluent-bit:3.2.10
     volumes:
-      - ../logs:/var/log/app:ro
+      - ../logs/reactive:/var/log/app:ro
       - ../monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
       - ../monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
     depends_on:

--- a/docker/compose.servlet.yml
+++ b/docker/compose.servlet.yml
@@ -1,6 +1,8 @@
-# Maven / contributor infra. Apps run on the host (mvn spring-boot:run).
+# Servlet stack: Postgres + Kafka + order-service + notification-stub.
 # Observability: docker compose --profile observability up -d
-# Keep Kafka listeners in sync with docker/compose.servlet.yml, compose.reactive.yml, compose.vt.yml.
+# Keep Kafka listeners in sync with compose.reactive.yml, compose.vt.yml, and ../docker-compose.yml.
+name: outbox-servlet
+
 services:
   postgres:
     image: postgres:18.4
@@ -10,8 +12,6 @@ services:
       POSTGRES_PASSWORD: outbox
     ports:
       - "5432:5432"
-    volumes:
-      - ./docker/postgres/init-databases.sql:/docker-entrypoint-initdb.d/01-init-databases.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U outbox -d outbox"]
       interval: 5s
@@ -62,6 +62,50 @@ services:
           --replication-factor 1
         echo "Topic orders.events is ready (10 partitions)"
 
+  order-service:
+    image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/order-service:${APP_VERSION:-latest}
+    ports:
+      - "8080:8080"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_NAME: outbox
+      DB_USER: outbox
+      DB_PASSWORD: outbox
+      KAFKA_BOOTSTRAP: kafka:29092
+      SERVER_PORT: "8080"
+      LOG_JSON_PATH: /var/log/app
+      DEPLOYMENT_ENV: local
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+    volumes:
+      - ../logs:/var/log/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+
+  notification-stub:
+    image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/notification-stub:${APP_VERSION:-latest}
+    ports:
+      - "8081:8081"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      KAFKA_BOOTSTRAP: kafka:29092
+      LOG_JSON_PATH: /var/log/app
+      DEPLOYMENT_ENV: local
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+    volumes:
+      - ../logs:/var/log/app
+    depends_on:
+      kafka-init:
+        condition: service_completed_successfully
+      order-service:
+        condition: service_started
+
   postgres-exporter:
     profiles: ["observability"]
     image: prometheuscommunity/postgres-exporter:v0.17.1
@@ -81,7 +125,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
@@ -98,7 +142,7 @@ services:
       GF_RENDERING_SERVER_URL: http://grafana-image-renderer:8081/render
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/
     volumes:
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
       - tempo
@@ -118,7 +162,7 @@ services:
       - "3200:3200"
       - "4318:4318"
     volumes:
-      - ./monitoring/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - ../monitoring/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
 
   opensearch:
     profiles: ["observability"]
@@ -149,7 +193,7 @@ services:
     image: curlimages/curl:8.12.1
     restart: "no"
     volumes:
-      - ./monitoring/opensearch/index-template.json:/index-template.json:ro
+      - ../monitoring/opensearch/index-template.json:/index-template.json:ro
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -167,7 +211,7 @@ services:
     image: curlimages/curl:8.12.1
     restart: "no"
     volumes:
-      - ./monitoring/opensearch-dashboards/saved-objects.ndjson:/saved-objects.ndjson:ro
+      - ../monitoring/opensearch-dashboards/saved-objects.ndjson:/saved-objects.ndjson:ro
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -185,9 +229,9 @@ services:
     profiles: ["observability"]
     image: fluent/fluent-bit:3.2.10
     volumes:
-      - ./logs:/var/log/app:ro
-      - ./monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
-      - ./monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
+      - ../logs:/var/log/app:ro
+      - ../monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
+      - ../monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
     depends_on:
       - opensearch
 

--- a/docker/compose.servlet.yml
+++ b/docker/compose.servlet.yml
@@ -1,6 +1,5 @@
-# Servlet stack: Postgres + Kafka + order-service + notification-stub.
-# Observability: docker compose --profile observability up -d
-# Keep Kafka listeners in sync with compose.reactive.yml, compose.vt.yml, and ../docker-compose.yml.
+# Servlet stack. Host ports do not overlap with compose.reactive.yml / compose.vt.yml.
+# Order 8090, stub 8091, Grafana 3000. Keep Kafka listeners in sync across flavor files.
 name: outbox-servlet
 
 services:
@@ -21,12 +20,12 @@ services:
   kafka:
     image: apache/kafka:3.9.1
     ports:
-      - "9092:9092"
+      - "19092:9092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:19092
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
@@ -50,12 +49,12 @@ services:
       - |
         echo "Waiting for Kafka..."
         for i in $$(seq 1 30); do
-          if /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1; then
+          if /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:29092 --list >/dev/null 2>&1; then
             break
           fi
           sleep 2
         done
-        /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 \
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:29092 \
           --create --if-not-exists \
           --topic orders.events \
           --partitions 10 \
@@ -65,7 +64,7 @@ services:
   order-service:
     image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/order-service:${APP_VERSION:-latest}
     ports:
-      - "8080:8080"
+      - "8090:8080"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -76,11 +75,12 @@ services:
       DB_PASSWORD: outbox
       KAFKA_BOOTSTRAP: kafka:29092
       SERVER_PORT: "8080"
+      SPRING_PROFILES_ACTIVE: dev
       LOG_JSON_PATH: /var/log/app
       DEPLOYMENT_ENV: local
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318/v1/traces
     volumes:
-      - ../logs:/var/log/app
+      - ../logs/servlet:/var/log/app
     depends_on:
       postgres:
         condition: service_healthy
@@ -90,16 +90,17 @@ services:
   notification-stub:
     image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/notification-stub:${APP_VERSION:-latest}
     ports:
-      - "8081:8081"
+      - "8091:8081"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
       KAFKA_BOOTSTRAP: kafka:29092
+      SPRING_PROFILES_ACTIVE: dev
       LOG_JSON_PATH: /var/log/app
       DEPLOYMENT_ENV: local
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318/v1/traces
     volumes:
-      - ../logs:/var/log/app
+      - ../logs/servlet:/var/log/app
     depends_on:
       kafka-init:
         condition: service_completed_successfully
@@ -121,11 +122,9 @@ services:
     profiles: ["observability"]
     image: prom/prometheus:v3.5.0
     ports:
-      - "9090:9090"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - "9100:9090"
     volumes:
-      - ../monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../monitoring/prometheus/prometheus-servlet.yml:/etc/prometheus/prometheus.yml:ro
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
@@ -142,7 +141,13 @@ services:
       GF_RENDERING_SERVER_URL: http://grafana-image-renderer:8081/render
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/
     volumes:
-      - ../monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ../monitoring/grafana/provisioning/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ../monitoring/grafana/provisioning/dashboards/orders-technical-dashboard.json:/etc/grafana/provisioning/dashboards/orders-technical.json:ro
+      - ../monitoring/grafana/provisioning/dashboards/outbox-dashboard.json:/etc/grafana/provisioning/dashboards/outbox.json:ro
+      - ../monitoring/grafana/provisioning/dashboards/postgres-dashboard.json:/etc/grafana/provisioning/dashboards/postgres.json:ro
+      - ../monitoring/grafana/provisioning/dashboards/notification-stub-dashboard.json:/etc/grafana/provisioning/dashboards/notification-stub.json:ro
+      - ../monitoring/grafana/provisioning/dashboards/tracing-dashboard.json:/etc/grafana/provisioning/dashboards/tracing.json:ro
     depends_on:
       - prometheus
       - tempo
@@ -152,7 +157,7 @@ services:
     profiles: ["observability"]
     image: grafana/grafana-image-renderer:3.12.2
     ports:
-      - "8082:8081"
+      - "3191:8081"
 
   tempo:
     profiles: ["observability"]
@@ -229,7 +234,7 @@ services:
     profiles: ["observability"]
     image: fluent/fluent-bit:3.2.10
     volumes:
-      - ../logs:/var/log/app:ro
+      - ../logs/servlet:/var/log/app:ro
       - ../monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
       - ../monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
     depends_on:

--- a/docker/compose.vt.yml
+++ b/docker/compose.vt.yml
@@ -1,19 +1,19 @@
-# Maven / contributor infra. Apps run on the host (mvn spring-boot:run).
+# Virtual Threads stack: Postgres + Kafka + order-service-vt + notification-stub.
 # Observability: docker compose --profile observability up -d
-# Keep Kafka listeners in sync with docker/compose.servlet.yml, compose.reactive.yml, compose.vt.yml.
+# Keep Kafka listeners in sync with compose.servlet.yml, compose.reactive.yml, and ../docker-compose.yml.
+name: outbox-vt
+
 services:
   postgres:
     image: postgres:18.4
     environment:
-      POSTGRES_DB: outbox
+      POSTGRES_DB: outbox_vt
       POSTGRES_USER: outbox
       POSTGRES_PASSWORD: outbox
     ports:
       - "5432:5432"
-    volumes:
-      - ./docker/postgres/init-databases.sql:/docker-entrypoint-initdb.d/01-init-databases.sql:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U outbox -d outbox"]
+      test: ["CMD-SHELL", "pg_isready -U outbox -d outbox_vt"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -62,11 +62,55 @@ services:
           --replication-factor 1
         echo "Topic orders.events is ready (10 partitions)"
 
+  order-service:
+    image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/order-service-vt:${APP_VERSION:-latest}
+    ports:
+      - "8080:8080"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_NAME: outbox_vt
+      DB_USER: outbox
+      DB_PASSWORD: outbox
+      KAFKA_BOOTSTRAP: kafka:29092
+      SERVER_PORT: "8080"
+      LOG_JSON_PATH: /var/log/app
+      DEPLOYMENT_ENV: local
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+    volumes:
+      - ../logs:/var/log/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+
+  notification-stub:
+    image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/notification-stub:${APP_VERSION:-latest}
+    ports:
+      - "8081:8081"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      KAFKA_BOOTSTRAP: kafka:29092
+      LOG_JSON_PATH: /var/log/app
+      DEPLOYMENT_ENV: local
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+    volumes:
+      - ../logs:/var/log/app
+    depends_on:
+      kafka-init:
+        condition: service_completed_successfully
+      order-service:
+        condition: service_started
+
   postgres-exporter:
     profiles: ["observability"]
     image: prometheuscommunity/postgres-exporter:v0.17.1
     environment:
-      DATA_SOURCE_NAME: "postgresql://outbox:outbox@postgres:5432/outbox?sslmode=disable"
+      DATA_SOURCE_NAME: "postgresql://outbox:outbox@postgres:5432/outbox_vt?sslmode=disable"
     ports:
       - "9187:9187"
     depends_on:
@@ -81,7 +125,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
@@ -98,7 +142,7 @@ services:
       GF_RENDERING_SERVER_URL: http://grafana-image-renderer:8081/render
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/
     volumes:
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
       - tempo
@@ -118,7 +162,7 @@ services:
       - "3200:3200"
       - "4318:4318"
     volumes:
-      - ./monitoring/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - ../monitoring/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
 
   opensearch:
     profiles: ["observability"]
@@ -149,7 +193,7 @@ services:
     image: curlimages/curl:8.12.1
     restart: "no"
     volumes:
-      - ./monitoring/opensearch/index-template.json:/index-template.json:ro
+      - ../monitoring/opensearch/index-template.json:/index-template.json:ro
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -167,7 +211,7 @@ services:
     image: curlimages/curl:8.12.1
     restart: "no"
     volumes:
-      - ./monitoring/opensearch-dashboards/saved-objects.ndjson:/saved-objects.ndjson:ro
+      - ../monitoring/opensearch-dashboards/saved-objects.ndjson:/saved-objects.ndjson:ro
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -185,9 +229,9 @@ services:
     profiles: ["observability"]
     image: fluent/fluent-bit:3.2.10
     volumes:
-      - ./logs:/var/log/app:ro
-      - ./monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
-      - ./monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
+      - ../logs:/var/log/app:ro
+      - ../monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
+      - ../monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
     depends_on:
       - opensearch
 

--- a/docker/compose.vt.yml
+++ b/docker/compose.vt.yml
@@ -1,6 +1,5 @@
-# Virtual Threads stack: Postgres + Kafka + order-service-vt + notification-stub.
-# Observability: docker compose --profile observability up -d
-# Keep Kafka listeners in sync with compose.servlet.yml, compose.reactive.yml, and ../docker-compose.yml.
+# Virtual Threads stack. Host ports do not overlap with compose.servlet.yml / compose.reactive.yml.
+# Order 8094, stub 8095, Grafana 3002.
 name: outbox-vt
 
 services:
@@ -11,7 +10,7 @@ services:
       POSTGRES_USER: outbox
       POSTGRES_PASSWORD: outbox
     ports:
-      - "5432:5432"
+      - "5434:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U outbox -d outbox_vt"]
       interval: 5s
@@ -21,12 +20,12 @@ services:
   kafka:
     image: apache/kafka:3.9.1
     ports:
-      - "9092:9092"
+      - "19094:9092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:19094
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
@@ -50,12 +49,12 @@ services:
       - |
         echo "Waiting for Kafka..."
         for i in $$(seq 1 30); do
-          if /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1; then
+          if /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:29092 --list >/dev/null 2>&1; then
             break
           fi
           sleep 2
         done
-        /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 \
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:29092 \
           --create --if-not-exists \
           --topic orders.events \
           --partitions 10 \
@@ -65,7 +64,7 @@ services:
   order-service:
     image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/order-service-vt:${APP_VERSION:-latest}
     ports:
-      - "8080:8080"
+      - "8094:8080"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -76,11 +75,12 @@ services:
       DB_PASSWORD: outbox
       KAFKA_BOOTSTRAP: kafka:29092
       SERVER_PORT: "8080"
+      SPRING_PROFILES_ACTIVE: dev
       LOG_JSON_PATH: /var/log/app
       DEPLOYMENT_ENV: local
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318/v1/traces
     volumes:
-      - ../logs:/var/log/app
+      - ../logs/vt:/var/log/app
     depends_on:
       postgres:
         condition: service_healthy
@@ -90,16 +90,17 @@ services:
   notification-stub:
     image: ghcr.io/kholodilin/spring-transactional-outbox-kafka/notification-stub:${APP_VERSION:-latest}
     ports:
-      - "8081:8081"
+      - "8095:8081"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
       KAFKA_BOOTSTRAP: kafka:29092
+      SPRING_PROFILES_ACTIVE: dev
       LOG_JSON_PATH: /var/log/app
       DEPLOYMENT_ENV: local
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://host.docker.internal:4318/v1/traces
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318/v1/traces
     volumes:
-      - ../logs:/var/log/app
+      - ../logs/vt:/var/log/app
     depends_on:
       kafka-init:
         condition: service_completed_successfully
@@ -112,7 +113,7 @@ services:
     environment:
       DATA_SOURCE_NAME: "postgresql://outbox:outbox@postgres:5432/outbox_vt?sslmode=disable"
     ports:
-      - "9187:9187"
+      - "9189:9187"
     depends_on:
       postgres:
         condition: service_healthy
@@ -121,11 +122,9 @@ services:
     profiles: ["observability"]
     image: prom/prometheus:v3.5.0
     ports:
-      - "9090:9090"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - "9102:9090"
     volumes:
-      - ../monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../monitoring/prometheus/prometheus-vt.yml:/etc/prometheus/prometheus.yml:ro
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
@@ -134,7 +133,7 @@ services:
     profiles: ["observability"]
     image: grafana/grafana:12.3.3
     ports:
-      - "3000:3000"
+      - "3002:3000"
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
@@ -142,7 +141,12 @@ services:
       GF_RENDERING_SERVER_URL: http://grafana-image-renderer:8081/render
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/
     volumes:
-      - ../monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ../monitoring/grafana/provisioning/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ../monitoring/grafana/provisioning/dashboards/orders-technical-vt-dashboard.json:/etc/grafana/provisioning/dashboards/orders-technical.json:ro
+      - ../monitoring/grafana/provisioning/dashboards/postgres-dashboard.json:/etc/grafana/provisioning/dashboards/postgres.json:ro
+      - ../monitoring/grafana/provisioning/dashboards/notification-stub-dashboard.json:/etc/grafana/provisioning/dashboards/notification-stub.json:ro
+      - ../monitoring/grafana/provisioning/dashboards/tracing-dashboard.json:/etc/grafana/provisioning/dashboards/tracing.json:ro
     depends_on:
       - prometheus
       - tempo
@@ -152,15 +156,15 @@ services:
     profiles: ["observability"]
     image: grafana/grafana-image-renderer:3.12.2
     ports:
-      - "8082:8081"
+      - "3193:8081"
 
   tempo:
     profiles: ["observability"]
     image: grafana/tempo:2.8.0
     command: ["-config.file=/etc/tempo/tempo.yaml"]
     ports:
-      - "3200:3200"
-      - "4318:4318"
+      - "3202:3200"
+      - "4320:4318"
     volumes:
       - ../monitoring/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
 
@@ -173,7 +177,7 @@ services:
       OPENSEARCH_JAVA_OPTS: -Xms512m -Xmx512m
       DISABLE_INSTALL_DEMO_CONFIG: "true"
     ports:
-      - "9200:9200"
+      - "9202:9200"
     volumes:
       - opensearch-data:/usr/share/opensearch/data
 
@@ -181,7 +185,7 @@ services:
     profiles: ["observability"]
     image: opensearchproject/opensearch-dashboards:2.19.2
     ports:
-      - "5601:5601"
+      - "5603:5601"
     environment:
       OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
       DISABLE_SECURITY_DASHBOARDS_PLUGIN: "true"
@@ -229,7 +233,7 @@ services:
     profiles: ["observability"]
     image: fluent/fluent-bit:3.2.10
     volumes:
-      - ../logs:/var/log/app:ro
+      - ../logs/vt:/var/log/app:ro
       - ../monitoring/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
       - ../monitoring/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf:ro
     depends_on:

--- a/docs/ab-load-comparison.md
+++ b/docs/ab-load-comparison.md
@@ -10,7 +10,36 @@ Compare three peer order services **sequentially** on the same machine:
 
 Do not run more than one service under load at once if you want a clean CPU/IO comparison. Kafka topic `orders.events` is shared.
 
-## Prerequisites
+## Docker flavors (no Maven)
+
+Each stack is a separate compose file. Order service is always `:8080`. Tear one down before starting the next.
+
+```bash
+docker compose -f docker/compose.servlet.yml up -d
+mvn -pl load-tests gatling:test \
+  -Dgatling.simulationClass=com.kholodilin.outbox.loadtests.CreateOrderSimulation \
+  -DbaseUrl=http://localhost:8080 \
+  -Dprofile=warmup -DwarmupRps=50 -DloadRps=100 -DloadSeconds=120
+docker compose -f docker/compose.servlet.yml down -v
+
+docker compose -f docker/compose.reactive.yml up -d
+mvn -pl load-tests gatling:test \
+  -Dgatling.simulationClass=com.kholodilin.outbox.loadtests.CreateOrderReactiveSimulation \
+  -DbaseUrl=http://localhost:8080 \
+  -Dprofile=warmup -DwarmupRps=50 -DloadRps=100 -DloadSeconds=120
+docker compose -f docker/compose.reactive.yml down -v
+
+docker compose -f docker/compose.vt.yml up -d
+mvn -pl load-tests gatling:test \
+  -Dgatling.simulationClass=com.kholodilin.outbox.loadtests.CreateOrderVtSimulation \
+  -DbaseUrl=http://localhost:8080 \
+  -Dprofile=warmup -DwarmupRps=50 -DloadRps=100 -DloadSeconds=120
+docker compose -f docker/compose.vt.yml down -v
+```
+
+Add `--profile observability` when you want Grafana during the run.
+
+## Prerequisites (Maven on the host)
 
 ```bash
 docker compose up -d postgres kafka

--- a/docs/ab-load-comparison.md
+++ b/docs/ab-load-comparison.md
@@ -12,32 +12,33 @@ Do not run more than one service under load at once if you want a clean CPU/IO c
 
 ## Docker flavors (no Maven)
 
-Each stack is a separate compose file. Order service is always `:8080`. Tear one down before starting the next.
+Each stack is a separate compose file with its own ports, so all three can stay up. Load one at a time for a fair CPU/IO comparison. Grafana on each stack shows only that flavor's Orders Technical dashboard.
+
+| Peer | Order | Stub | Grafana |
+|------|-------|------|---------|
+| servlet | `:8090` | `:8091` | `:3000` |
+| reactive | `:8092` | `:8093` | `:3001` |
+| vt | `:8094` | `:8095` | `:3002` |
 
 ```bash
-docker compose -f docker/compose.servlet.yml up -d
+docker compose -f docker/compose.servlet.yml --profile observability up -d
 mvn -pl load-tests gatling:test \
   -Dgatling.simulationClass=com.kholodilin.outbox.loadtests.CreateOrderSimulation \
-  -DbaseUrl=http://localhost:8080 \
+  -DbaseUrl=http://localhost:8090 \
   -Dprofile=warmup -DwarmupRps=50 -DloadRps=100 -DloadSeconds=120
-docker compose -f docker/compose.servlet.yml down -v
 
-docker compose -f docker/compose.reactive.yml up -d
+docker compose -f docker/compose.reactive.yml --profile observability up -d
 mvn -pl load-tests gatling:test \
   -Dgatling.simulationClass=com.kholodilin.outbox.loadtests.CreateOrderReactiveSimulation \
-  -DbaseUrl=http://localhost:8080 \
+  -DbaseUrl=http://localhost:8092 \
   -Dprofile=warmup -DwarmupRps=50 -DloadRps=100 -DloadSeconds=120
-docker compose -f docker/compose.reactive.yml down -v
 
-docker compose -f docker/compose.vt.yml up -d
+docker compose -f docker/compose.vt.yml --profile observability up -d
 mvn -pl load-tests gatling:test \
   -Dgatling.simulationClass=com.kholodilin.outbox.loadtests.CreateOrderVtSimulation \
-  -DbaseUrl=http://localhost:8080 \
+  -DbaseUrl=http://localhost:8094 \
   -Dprofile=warmup -DwarmupRps=50 -DloadRps=100 -DloadSeconds=120
-docker compose -f docker/compose.vt.yml down -v
 ```
-
-Add `--profile observability` when you want Grafana during the run.
 
 ## Prerequisites (Maven on the host)
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -26,7 +26,7 @@ Micrometer Tracing (`traceId`, `spanId`) is reused — no second tracing stack.
 ### 1. Start infrastructure
 
 ```bash
-docker compose up -d
+docker compose --profile observability up -d
 ```
 
 Includes OpenSearch (`9200`), OpenSearch Dashboards (`5601`), and Fluent Bit.
@@ -67,7 +67,7 @@ curl -X POST http://localhost:8080/api/v1/orders \
 ### 4. OpenSearch Dashboards
 
 1. Open http://localhost:5601
-2. Dashboards are imported automatically on `docker compose up` (service `opensearch-dashboards-init`).
+2. Dashboards are imported automatically on `docker compose --profile observability up` (service `opensearch-dashboards-init`).
 3. If missing, import manually: **Stack Management → Saved Objects → Import** → `monitoring/opensearch-dashboards/saved-objects.ndjson`
 4. Open dashboard **Transactional Outbox Overview**
 

--- a/monitoring/fluent-bit/fluent-bit.conf
+++ b/monitoring/fluent-bit/fluent-bit.conf
@@ -6,7 +6,7 @@
 
 [INPUT]
     Name              tail
-    Path              /var/log/app/order-service/order-service/app.json,/var/log/app/notification-stub/notification-stub/app.json,/var/log/app/order-service-reactive/order-service-reactive/app.json,/var/log/app/order-service-vt/order-service-vt/app.json
+    Path              /var/log/app/order-service/app.json,/var/log/app/notification-stub/app.json,/var/log/app/order-service-reactive/app.json,/var/log/app/order-service-vt/app.json
     Parser            json
     Tag               spring.outbox
     Refresh_Interval  5

--- a/monitoring/prometheus/prometheus-reactive.yml
+++ b/monitoring/prometheus/prometheus-reactive.yml
@@ -1,0 +1,23 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: order-service-reactive
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["order-service:8080"]
+
+  - job_name: notification-stub
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["notification-stub:8081"]
+
+  - job_name: postgres
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
+  - job_name: tempo
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["tempo:3200"]

--- a/monitoring/prometheus/prometheus-servlet.yml
+++ b/monitoring/prometheus/prometheus-servlet.yml
@@ -1,0 +1,23 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: order-service
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["order-service:8080"]
+
+  - job_name: notification-stub
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["notification-stub:8081"]
+
+  - job_name: postgres
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
+  - job_name: tempo
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["tempo:3200"]

--- a/monitoring/prometheus/prometheus-vt.yml
+++ b/monitoring/prometheus/prometheus-vt.yml
@@ -1,0 +1,23 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: order-service-vt
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["order-service:8080"]
+
+  - job_name: notification-stub
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["notification-stub:8081"]
+
+  - job_name: postgres
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
+  - job_name: tempo
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["tempo:3200"]

--- a/notification-stub/Dockerfile
+++ b/notification-stub/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/log/app
+
+COPY target/notification-stub-*.jar app.jar
+
+EXPOSE 8081
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=60s --retries=10 \
+    CMD curl -sf http://localhost:8081/actuator/health | grep -q UP || exit 1
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/order-service-reactive/Dockerfile
+++ b/order-service-reactive/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/log/app
+
+COPY target/order-service-reactive-*.jar app.jar
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=90s --retries=10 \
+    CMD curl -sf http://localhost:8080/actuator/health | grep -q UP || exit 1
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/order-service-vt/Dockerfile
+++ b/order-service-vt/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/log/app
+
+COPY target/order-service-vt-*.jar app.jar
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=90s --retries=10 \
+    CMD curl -sf http://localhost:8080/actuator/health | grep -q UP || exit 1
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/log/app
+
+COPY target/order-service-*.jar app.jar
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=90s --retries=10 \
+    CMD curl -sf http://localhost:8080/actuator/health | grep -q UP || exit 1
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary

Adds a Docker-first demo path: three compose flavors (servlet / WebFlux / VT), GHCR images, and a tag-driven GitHub Release so the example starts without Java or Maven.

- Dockerfiles for `order-service`, `order-service-reactive`, `order-service-vt`, and `notification-stub`
- `docker/compose.servlet.yml`, `compose.reactive.yml`, `compose.vt.yml` — same host ports (`8080` / `8081`); Kafka dual listeners (`localhost:9092` + `kafka:29092`)
- Root `docker-compose.yml` stays infra for Maven; Grafana/Prometheus/OpenSearch behind `--profile observability`
- `.github/workflows/release.yml` on `v*`: package, push GHCR, attach the three compose files with pinned image tags

## Related issues

Fixes #48

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation update
- [ ] Refactoring / chore

`docker compose up -d` no longer starts Grafana/OpenSearch; use `--profile observability`.

## Affected modules

- [ ] `outbox-events-contract`
- [ ] `order-service`
- [ ] `order-service-reactive`
- [ ] `order-service-vt`
- [ ] `notification-stub`
- [x] `docker-compose` / infrastructure
- [x] docs / CI / other

(Dockerfiles added next to the four app modules; no Java behavior change.)

## Test plan

- [ ] `mvn clean verify`
- [x] Manual testing (describe below)

**Manual steps (if any):**

```bash
docker compose -f docker/compose.servlet.yml config --quiet
docker compose -f docker/compose.reactive.yml config --quiet
docker compose -f docker/compose.vt.yml config --quiet
docker compose --profile observability config --quiet
```

Images and a GitHub Release appear after merging and pushing a `v*` tag (not from this branch).

## Checklist

- [x] Code follows existing project conventions
- [ ] Tests added or updated where appropriate
- [x] Documentation updated (if user-facing behavior changed)
- [x] No secrets or environment-specific credentials committed
- [ ] Liquibase/schema changes documented (if applicable)
- [ ] Codecov patch coverage check is green (or explained in PR description)

No Java production code changed; Codecov patch coverage is not applicable.