### PR TITLE
Make notification consumer idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ As a result, recovery performance depends only on the number of active events in
 
 Servlet and Virtual Threads peers use [`spring-boot-idempotency-starter`](https://github.com/KHolodilin/spring-boot-idempotency-starter) (fluent API) and [`spring-boot-outbox-starter`](https://github.com/KHolodilin/spring-boot-outbox-starter) with PostgreSQL tables `idempotency_records` / `outbox_events`. The idempotency outcome is committed in the **same transaction** as the order and outbox row.
 
+The Notification Stub also uses the idempotency starter to process each Kafka `eventId` once, storing consumer-side records in its own `notification_idempotency_records` table.
+
 ```mermaid
 sequenceDiagram
     actor Client

--- a/docker/compose.reactive.yml
+++ b/docker/compose.reactive.yml
@@ -94,6 +94,11 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_NAME: outbox_reactive
+      DB_USER: outbox
+      DB_PASSWORD: outbox
       KAFKA_BOOTSTRAP: kafka:29092
       SPRING_PROFILES_ACTIVE: dev
       LOG_JSON_PATH: /var/log/app
@@ -102,6 +107,8 @@ services:
     volumes:
       - ../logs/reactive:/var/log/app
     depends_on:
+      postgres:
+        condition: service_healthy
       kafka-init:
         condition: service_completed_successfully
       order-service:

--- a/docker/compose.servlet.yml
+++ b/docker/compose.servlet.yml
@@ -94,6 +94,11 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_NAME: outbox
+      DB_USER: outbox
+      DB_PASSWORD: outbox
       KAFKA_BOOTSTRAP: kafka:29092
       SPRING_PROFILES_ACTIVE: dev
       LOG_JSON_PATH: /var/log/app
@@ -102,6 +107,8 @@ services:
     volumes:
       - ../logs/servlet:/var/log/app
     depends_on:
+      postgres:
+        condition: service_healthy
       kafka-init:
         condition: service_completed_successfully
       order-service:

--- a/docker/compose.vt.yml
+++ b/docker/compose.vt.yml
@@ -94,6 +94,11 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_NAME: outbox_vt
+      DB_USER: outbox
+      DB_PASSWORD: outbox
       KAFKA_BOOTSTRAP: kafka:29092
       SPRING_PROFILES_ACTIVE: dev
       LOG_JSON_PATH: /var/log/app
@@ -102,6 +107,8 @@ services:
     volumes:
       - ../logs/vt:/var/log/app
     depends_on:
+      postgres:
+        condition: service_healthy
       kafka-init:
         condition: service_completed_successfully
       order-service:

--- a/docs/spring-transactional-outbox-kafka-OpenSearch-Logging-Spec.md
+++ b/docs/spring-transactional-outbox-kafka-OpenSearch-Logging-Spec.md
@@ -268,6 +268,8 @@ Notification Stub
 -   notification.batch.received
 -   notification.processing.started
 -   notification.processed
+-   notification.duplicate.skipped
+-   notification.conflict.skipped
 -   notification.processing.failed
 
 ------------------------------------------------------------------------

--- a/notification-stub/pom.xml
+++ b/notification-stub/pom.xml
@@ -28,6 +28,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.kholodilin</groupId>
+            <artifactId>spring-boot-idempotency-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
@@ -52,6 +60,15 @@
             <artifactId>spring-boot-starter-kafka</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-liquibase</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
@@ -61,10 +78,49 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*IT.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <argLine>@{it.argLine} ${mockito.agent.argLine}</argLine>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/notification-stub/src/main/java/com/kholodilin/outbox/notification/NotificationStubHandler.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/notification/NotificationStubHandler.java
@@ -1,5 +1,6 @@
 package com.kholodilin.outbox.notification;
 
+import com.kholodilin.idempotency.exception.IdempotencyConflictException;
 import com.kholodilin.outbox.events.EventConstants;
 import com.kholodilin.outbox.events.EventEnvelope;
 import com.kholodilin.outbox.logging.InstanceMdcInitializer;
@@ -30,9 +31,10 @@ public class NotificationStubHandler {
     private final NotificationStubMetrics metrics;
     private final TraceContextSupport traceContextSupport;
     private final InstanceMdcInitializer instanceMdcInitializer;
+    private final NotificationTransactionService notificationTransactionService;
 
     /**
-     * Consumes a Kafka batch of order events and logs a mock notification per record.
+     * Consumes a Kafka batch of order events and processes each mock notification idempotently.
      * <p>
      * Restores W3C {@code traceparent} for the batch span and again per record so Tempo
      * continues the publisher's trace. Metrics record batch size and processing time.
@@ -60,7 +62,7 @@ public class NotificationStubHandler {
                     traceContextSupport.runWithTraceParent(
                             extractTraceParent(record),
                             "notification.consume",
-                            () -> logEvent(record)
+                            () -> processRecord(record)
                     );
                 }
                 StructuredLogContext.putDurationMs((System.nanoTime() - start) / 1_000_000);
@@ -71,20 +73,33 @@ public class NotificationStubHandler {
         });
     }
 
-    private void logEvent(ConsumerRecord<String, EventEnvelope> record) {
+    private void processRecord(ConsumerRecord<String, EventEnvelope> record) {
         EventEnvelope event = record.value();
         instanceMdcInitializer.enrich();
         StructuredLogContext.putCorrelation(event.correlationId(), event.customerId());
         StructuredLogContext.putOrderFields(event.orderId(), event.eventId());
         StructuredLogContext.putEventType(event.eventType());
         StructuredLogContext.putKafkaFields(record.topic(), record.partition(), record.offset());
-        StructuredLogContext.putNotificationFields("log", "sent");
-        StructuredLogContext.putEventAction("notification.processed");
-        log.info("Notification stub sent orderId={} customerId={} eventId={}",
-                event.orderId(), event.customerId(), event.eventId());
-        log.debug("Notification stub event details eventType={} correlationId={} payload={}",
-                event.eventType(), event.correlationId(), event.payload());
-        instanceMdcInitializer.clearConsumerContext();
+        try {
+            boolean sent = notificationTransactionService.process(event);
+            if (!sent) {
+                StructuredLogContext.putNotificationFields("log", "skipped");
+                StructuredLogContext.putEventAction("notification.duplicate.skipped");
+                log.info("Notification stub skipped duplicate eventId={}", event.eventId());
+            }
+        } catch (IdempotencyConflictException ex) {
+            StructuredLogContext.putNotificationFields("log", "skipped");
+            StructuredLogContext.putEventAction("notification.conflict.skipped");
+            log.warn("Notification stub skipped conflicting eventId={} reason={}",
+                    event.eventId(), ex.getMessage());
+        } catch (RuntimeException ex) {
+            StructuredLogContext.putNotificationFields("log", "failed");
+            StructuredLogContext.putEventAction("notification.processing.failed");
+            log.error("Notification stub failed eventId={}", event.eventId(), ex);
+            throw ex;
+        } finally {
+            instanceMdcInitializer.clearConsumerContext();
+        }
     }
 
     private String extractTraceParent(ConsumerRecord<String, EventEnvelope> record) {

--- a/notification-stub/src/main/java/com/kholodilin/outbox/notification/NotificationTransactionService.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/notification/NotificationTransactionService.java
@@ -1,0 +1,56 @@
+package com.kholodilin.outbox.notification;
+
+import com.kholodilin.idempotency.ExecutionResult;
+import com.kholodilin.idempotency.IdempotencyService;
+import com.kholodilin.outbox.events.EventEnvelope;
+import com.kholodilin.outbox.logging.StructuredLogContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Processes one notification event in its own idempotent database transaction. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationTransactionService {
+
+    private static final String OPERATION = "NOTIFY_ORDER_CREATED";
+
+    private final IdempotencyService idempotencyService;
+
+    /**
+     * Sends the mock notification only when the event has not already been processed.
+     *
+     * @param event consumed Kafka event
+     * @return {@code true} when the notification action ran; {@code false} for a replay
+     */
+    @Transactional
+    public boolean process(EventEnvelope event) {
+        AtomicBoolean executed = new AtomicBoolean(false);
+
+        ExecutionResult<Void> result = idempotencyService
+                .operation(OPERATION)
+                .key(String.valueOf(event.eventId()))
+                .request(event)
+                .execute(Void.class, () -> {
+                    executed.set(true);
+                    logNotification(event);
+                    return ExecutionResult.success(null);
+                });
+
+        result.valueOrThrow();
+        return executed.get();
+    }
+
+    private void logNotification(EventEnvelope event) {
+        StructuredLogContext.putNotificationFields("log", "sent");
+        StructuredLogContext.putEventAction("notification.processed");
+        log.info("Notification stub sent orderId={} customerId={} eventId={}",
+                event.orderId(), event.customerId(), event.eventId());
+        log.debug("Notification stub event details eventType={} correlationId={} payload={}",
+                event.eventType(), event.correlationId(), event.payload());
+    }
+}

--- a/notification-stub/src/main/java/com/kholodilin/outbox/notification/NotificationTransactionService.java
+++ b/notification-stub/src/main/java/com/kholodilin/outbox/notification/NotificationTransactionService.java
@@ -6,6 +6,7 @@ import com.kholodilin.outbox.events.EventEnvelope;
 import com.kholodilin.outbox.logging.StructuredLogContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@DependsOnDatabaseInitialization
 public class NotificationTransactionService {
 
     private static final String OPERATION = "NOTIFY_ORDER_CREATED";

--- a/notification-stub/src/main/resources/application.yml
+++ b/notification-stub/src/main/resources/application.yml
@@ -1,6 +1,14 @@
 spring:
   application:
     name: notification-stub
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:outbox}
+    username: ${DB_USER:outbox}
+    password: ${DB_PASSWORD:outbox}
+    hikari:
+      connection-init-sql: SET TIME ZONE 'UTC'
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.yaml
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP:localhost:9092}
     listener:
@@ -36,6 +44,14 @@ logging:
   level:
     root: INFO
     com.kholodilin.outbox: INFO
+
+idempotency:
+  enabled: true
+  persistence:
+    enabled: true
+    table-name: notification_idempotency_records
+    schema:
+      mode: validate
 
 deployment:
   environment: ${DEPLOYMENT_ENV:local}

--- a/notification-stub/src/main/resources/db/changelog/changes/001-notification-idempotency-records.sql
+++ b/notification-stub/src/main/resources/db/changelog/changes/001-notification-idempotency-records.sql
@@ -1,0 +1,19 @@
+--liquibase formatted sql
+
+--changeset notification:001-idempotency-records
+CREATE TABLE notification_idempotency_records (
+    operation        VARCHAR(128)  NOT NULL,
+    idempotency_key  VARCHAR(255)  NOT NULL,
+    request_hash     VARCHAR(128)  NOT NULL,
+    status           VARCHAR(32)   NOT NULL,
+    result_type      VARCHAR(255),
+    result_payload   JSONB,
+    error_code       VARCHAR(128),
+    created_at       TIMESTAMPTZ   NOT NULL,
+    completed_at     TIMESTAMPTZ,
+    expires_at       TIMESTAMPTZ,
+    PRIMARY KEY (operation, idempotency_key)
+);
+
+CREATE INDEX idx_notification_idempotency_records_expires_at
+    ON notification_idempotency_records (expires_at);

--- a/notification-stub/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/notification-stub/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      file: changes/001-notification-idempotency-records.sql
+      relativeToChangelogFile: true

--- a/notification-stub/src/test/java/com/kholodilin/outbox/notification/NotificationIdempotencyIT.java
+++ b/notification-stub/src/test/java/com/kholodilin/outbox/notification/NotificationIdempotencyIT.java
@@ -1,0 +1,73 @@
+package com.kholodilin.outbox.notification;
+
+import com.kholodilin.idempotency.exception.IdempotencyConflictException;
+import com.kholodilin.outbox.events.EventEnvelope;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(classes = NotificationIdempotencyIT.TestApplication.class)
+@ActiveProfiles("test")
+class NotificationIdempotencyIT {
+
+    private static final AtomicLong EVENT_IDS = new AtomicLong(10_000);
+
+    @Autowired
+    private NotificationTransactionService service;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void firstDeliveryRunsAndReplayIsSkipped() {
+        long eventId = EVENT_IDS.incrementAndGet();
+        EventEnvelope event = event(eventId, Map.of("orderId", 2));
+
+        assertThat(service.process(event)).isTrue();
+        assertThat(service.process(event)).isFalse();
+        assertThat(recordCount(eventId)).isOne();
+    }
+
+    @Test
+    void sameEventIdWithDifferentBodyRaisesConflict() {
+        long eventId = EVENT_IDS.incrementAndGet();
+        EventEnvelope first = event(eventId, Map.of("version", 1));
+        EventEnvelope conflicting = event(eventId, Map.of("version", 2));
+
+        assertThat(service.process(first)).isTrue();
+        assertThatThrownBy(() -> service.process(conflicting))
+                .isInstanceOf(IdempotencyConflictException.class);
+        assertThat(recordCount(eventId)).isOne();
+    }
+
+    private int recordCount(long eventId) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM notification_idempotency_records WHERE idempotency_key = ?",
+                Integer.class,
+                String.valueOf(eventId)
+        );
+        return count == null ? 0 : count;
+    }
+
+    private EventEnvelope event(long eventId, Map<String, Object> payload) {
+        return new EventEnvelope(eventId, 2L, 3L, "OrderCreated", payload, "corr", null, null);
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration(exclude = KafkaAutoConfiguration.class)
+    @Import(NotificationTransactionService.class)
+    static class TestApplication {
+    }
+}

--- a/notification-stub/src/test/java/com/kholodilin/outbox/notification/NotificationStubHandlerTest.java
+++ b/notification-stub/src/test/java/com/kholodilin/outbox/notification/NotificationStubHandlerTest.java
@@ -1,5 +1,7 @@
 package com.kholodilin.outbox.notification;
 
+import com.kholodilin.idempotency.exception.IdempotencyConflictException;
+import com.kholodilin.idempotency.model.IdempotencyKey;
 import com.kholodilin.outbox.events.EventConstants;
 import com.kholodilin.outbox.events.EventEnvelope;
 import com.kholodilin.outbox.logging.InstanceMdcInitializer;
@@ -18,9 +20,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,6 +37,9 @@ class NotificationStubHandlerTest {
 
     @Mock
     private InstanceMdcInitializer instanceMdcInitializer;
+
+    @Mock
+    private NotificationTransactionService notificationTransactionService;
 
     @Test
     void ignoresEmptyBatch() {
@@ -65,6 +72,7 @@ class NotificationStubHandlerTest {
 
         handler.handleBatch(List.of(record));
 
+        verify(notificationTransactionService).process(envelope);
         verify(instanceMdcInitializer, times(2)).enrich();
         verify(instanceMdcInitializer, times(2)).clearConsumerContext();
     }
@@ -90,10 +98,48 @@ class NotificationStubHandlerTest {
         verify(instanceMdcInitializer, times(2)).enrich();
     }
 
+    @Test
+    void continuesBatchAfterIdempotencyConflict() {
+        stubTraceContext();
+        NotificationStubHandler handler = newHandler();
+        EventEnvelope conflicting = envelope(10L, Map.of("version", 2));
+        EventEnvelope next = envelope(11L, Map.of("version", 1));
+        doThrow(new IdempotencyConflictException(
+                new IdempotencyKey("NOTIFY_ORDER_CREATED", "10"),
+                "hash-a",
+                "hash-b"
+        )).when(notificationTransactionService).process(conflicting);
+
+        handler.handleBatch(List.of(record(conflicting, 10L), record(next, 11L)));
+
+        verify(notificationTransactionService).process(conflicting);
+        verify(notificationTransactionService).process(next);
+        verify(instanceMdcInitializer, times(3)).clearConsumerContext();
+    }
+
+    @Test
+    void propagatesTechnicalFailureSoKafkaCanRetryBatch() {
+        stubTraceContext();
+        NotificationStubHandler handler = newHandler();
+        EventEnvelope event = envelope(12L, Map.of("version", 1));
+        IllegalStateException failure = new IllegalStateException("database unavailable");
+        doThrow(failure).when(notificationTransactionService).process(event);
+
+        assertThatThrownBy(() -> handler.handleBatch(List.of(record(event, 12L))))
+                .isSameAs(failure);
+
+        verify(instanceMdcInitializer).clearConsumerContext();
+    }
+
     private NotificationStubHandler newHandler() {
         NotificationStubMetrics metrics = new NotificationStubMetrics(new SimpleMeterRegistry());
         ReflectionTestUtils.invokeMethod(metrics, "registerMeters");
-        return new NotificationStubHandler(metrics, traceContextSupport, instanceMdcInitializer);
+        return new NotificationStubHandler(
+                metrics,
+                traceContextSupport,
+                instanceMdcInitializer,
+                notificationTransactionService
+        );
     }
 
     private void stubTraceContext() {
@@ -102,5 +148,13 @@ class NotificationStubHandlerTest {
             action.run();
             return null;
         }).when(traceContextSupport).runWithTraceParent(any(), anyString(), any(Runnable.class));
+    }
+
+    private EventEnvelope envelope(long eventId, Map<String, Object> payload) {
+        return new EventEnvelope(eventId, 2L, 3L, "OrderCreated", payload, "corr", null, null);
+    }
+
+    private ConsumerRecord<String, EventEnvelope> record(EventEnvelope event, long offset) {
+        return new ConsumerRecord<>("orders.events", 0, offset, String.valueOf(event.customerId()), event);
     }
 }

--- a/notification-stub/src/test/java/com/kholodilin/outbox/notification/NotificationStubHandlerTest.java
+++ b/notification-stub/src/test/java/com/kholodilin/outbox/notification/NotificationStubHandlerTest.java
@@ -14,12 +14,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -28,6 +31,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationStubHandlerTest {
@@ -69,6 +73,7 @@ class NotificationStubHandlerTest {
                 EventConstants.HEADER_TRACEPARENT,
                 "00-trace".getBytes(StandardCharsets.UTF_8)
         ));
+        when(notificationTransactionService.process(envelope)).thenReturn(true);
 
         handler.handleBatch(List.of(record));
 
@@ -92,10 +97,43 @@ class NotificationStubHandlerTest {
                 null
         );
         ConsumerRecord<String, EventEnvelope> record = new ConsumerRecord<>("orders.events", 1, 9L, "7", envelope);
+        when(notificationTransactionService.process(envelope)).thenReturn(true);
 
         handler.handleBatch(List.of(record));
 
         verify(instanceMdcInitializer, times(2)).enrich();
+    }
+
+    @Test
+    @ExtendWith(OutputCaptureExtension.class)
+    void successfulNotificationDoesNotLogDuplicate(CapturedOutput output) {
+        stubTraceContext();
+        NotificationStubHandler handler = newHandler();
+        EventEnvelope event = envelope(13L, Map.of("version", 1));
+        when(notificationTransactionService.process(event)).thenReturn(true);
+
+        handler.handleBatch(List.of(record(event, 13L)));
+
+        verify(notificationTransactionService).process(event);
+        verify(instanceMdcInitializer, times(2)).clearConsumerContext();
+        assertThat(output).contains("Notification stub batch processed size=1")
+                .doesNotContain("Notification stub skipped duplicate");
+    }
+
+    @Test
+    @ExtendWith(OutputCaptureExtension.class)
+    void duplicateNotificationIsSkipped(CapturedOutput output) {
+        stubTraceContext();
+        NotificationStubHandler handler = newHandler();
+        EventEnvelope event = envelope(14L, Map.of("version", 1));
+        when(notificationTransactionService.process(event)).thenReturn(false);
+
+        handler.handleBatch(List.of(record(event, 14L)));
+
+        verify(notificationTransactionService).process(event);
+        verify(instanceMdcInitializer, times(2)).clearConsumerContext();
+        assertThat(output).contains("Notification stub skipped duplicate eventId=14")
+                .contains("Notification stub batch processed size=1");
     }
 
     @Test
@@ -109,6 +147,7 @@ class NotificationStubHandlerTest {
                 "hash-a",
                 "hash-b"
         )).when(notificationTransactionService).process(conflicting);
+        when(notificationTransactionService.process(next)).thenReturn(true);
 
         handler.handleBatch(List.of(record(conflicting, 10L), record(next, 11L)));
 

--- a/notification-stub/src/test/java/com/kholodilin/outbox/notification/NotificationTransactionServiceTest.java
+++ b/notification-stub/src/test/java/com/kholodilin/outbox/notification/NotificationTransactionServiceTest.java
@@ -1,0 +1,84 @@
+package com.kholodilin.outbox.notification;
+
+import com.kholodilin.idempotency.ExecutionResult;
+import com.kholodilin.idempotency.IdempotencyCall;
+import com.kholodilin.idempotency.IdempotencyService;
+import com.kholodilin.outbox.events.EventEnvelope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationTransactionServiceTest {
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private IdempotencyCall idempotencyCall;
+
+    private NotificationTransactionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new NotificationTransactionService(idempotencyService);
+    }
+
+    @Test
+    void firstEventExecutesNotificationAction() {
+        EventEnvelope event = event(42L);
+        stubCall(event);
+        when(idempotencyCall.execute(eq(Void.class), any())).thenAnswer(invocation -> {
+            Supplier<ExecutionResult<Void>> action = invocation.getArgument(1);
+            return action.get();
+        });
+
+        boolean sent = service.process(event);
+
+        assertThat(sent).isTrue();
+        verify(idempotencyService).operation("NOTIFY_ORDER_CREATED");
+        verify(idempotencyCall).key("42");
+        verify(idempotencyCall).request(event);
+    }
+
+    @Test
+    void replaySkipsNotificationAction() {
+        EventEnvelope event = event(42L);
+        stubCall(event);
+        when(idempotencyCall.execute(eq(Void.class), any())).thenReturn(ExecutionResult.success(null));
+
+        boolean sent = service.process(event);
+
+        assertThat(sent).isFalse();
+    }
+
+    private void stubCall(EventEnvelope event) {
+        when(idempotencyService.operation("NOTIFY_ORDER_CREATED")).thenReturn(idempotencyCall);
+        when(idempotencyCall.key("42")).thenReturn(idempotencyCall);
+        when(idempotencyCall.request(event)).thenReturn(idempotencyCall);
+    }
+
+    private EventEnvelope event(long eventId) {
+        return new EventEnvelope(
+                eventId,
+                2L,
+                3L,
+                "OrderCreated",
+                Map.of("orderId", 2),
+                "corr",
+                null,
+                null
+        );
+    }
+}

--- a/notification-stub/src/test/resources/application-test.yml
+++ b/notification-stub/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    url: jdbc:tc:postgresql:16-alpine:///outbox
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  liquibase:
+    enabled: true
+
+management:
+  opentelemetry:
+    enabled: false
+  tracing:
+    enabled: false
+
+idempotency:
+  enabled: true
+  persistence:
+    enabled: true
+    table-name: notification_idempotency_records
+    schema:
+      mode: validate
+
+logging:
+  level:
+    com.kholodilin.outbox: INFO


### PR DESCRIPTION
## Summary

- process each notification event in a dedicated transaction using the parent-managed idempotency starter
- skip same-body replays, warn and continue on fingerprint conflicts, and fail the batch on technical errors
- add a module-owned Liquibase table, database configuration, Compose wiring, tests, and documentation

## Related issues

Closes #50

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation update
- [ ] Refactoring / chore

## Affected modules

- [ ] `outbox-events-contract`
- [ ] `order-service`
- [ ] `order-service-reactive`
- [ ] `order-service-vt`
- [x] `notification-stub`
- [x] `docker-compose` / infrastructure
- [x] docs / CI / other

## Test plan

- [ ] `mvn clean verify`
- [ ] Manual testing (describe below)
- [x] `mvn -pl notification-stub -am test`
- [x] `mvn -pl notification-stub -am verify -DskipITs`
- [x] YAML syntax validation for root and servlet/reactive/VT Compose files

**Manual steps (if any):**

```bash
# Docker is not available on the local machine. The added jdbc:tc PostgreSQL
# integration test is left for the GitHub Actions clean verify run.
```

## Checklist

- [x] Code follows existing project conventions
- [x] Tests added or updated where appropriate
- [x] Documentation updated (if user-facing behavior changed)
- [x] No secrets or environment-specific credentials committed
- [x] Liquibase/schema changes documented (if applicable)
- [ ] Codecov patch coverage check is green (pending CI)