### PR TITLE
Bump project version to 1.3.0-SNAPSHOT and refresh dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Servlet (`order-service`) and Virtual Threads (`order-service-vt`) get that pipe
 
 | Starter | Version | Repository |
 |---------|---------|------------|
-| `spring-boot-outbox-starter` | `0.1.0` | [KHolodilin/spring-boot-outbox-starter](https://github.com/KHolodilin/spring-boot-outbox-starter) |
-| `spring-boot-idempotency-starter` | `0.3.2` | [KHolodilin/spring-boot-idempotency-starter](https://github.com/KHolodilin/spring-boot-idempotency-starter) |
+| `spring-boot-outbox-starter` | `0.1.3` | [KHolodilin/spring-boot-outbox-starter](https://github.com/KHolodilin/spring-boot-outbox-starter) |
+| `spring-boot-idempotency-starter` | `0.3.4` | [KHolodilin/spring-boot-idempotency-starter](https://github.com/KHolodilin/spring-boot-idempotency-starter) |
 
 ## 🔄 How it works
 

--- a/load-tests/pom.xml
+++ b/load-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.kholodilin.outbox</groupId>
         <artifactId>spring-transactional-outbox-kafka</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>load-tests</artifactId>

--- a/notification-stub/pom.xml
+++ b/notification-stub/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.kholodilin.outbox</groupId>
         <artifactId>spring-transactional-outbox-kafka</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>notification-stub</artifactId>

--- a/order-service-reactive/pom.xml
+++ b/order-service-reactive/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.kholodilin.outbox</groupId>
         <artifactId>spring-transactional-outbox-kafka</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>order-service-reactive</artifactId>

--- a/order-service-vt/pom.xml
+++ b/order-service-vt/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.kholodilin.outbox</groupId>
         <artifactId>spring-transactional-outbox-kafka</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>order-service-vt</artifactId>

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.kholodilin.outbox</groupId>
         <artifactId>spring-transactional-outbox-kafka</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>order-service</artifactId>

--- a/outbox-events-contract/pom.xml
+++ b/outbox-events-contract/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.kholodilin.outbox</groupId>
         <artifactId>spring-transactional-outbox-kafka</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>outbox-events-contract</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
         <relativePath/>
     </parent>
 
     <groupId>com.kholodilin.outbox</groupId>
     <artifactId>spring-transactional-outbox-kafka</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>spring-transactional-outbox-kafka</name>
 
@@ -30,10 +30,10 @@
         <java.version>21</java.version>
         <bucket4j.version>8.10.1</bucket4j.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <jacoco.version>0.8.12</jacoco.version>
-        <logstash-logback-encoder.version>8.0</logstash-logback-encoder.version>
-        <idempotency-starter.version>0.3.2</idempotency-starter.version>
-        <outbox-starter.version>0.1.0</outbox-starter.version>
+        <jacoco.version>0.8.15</jacoco.version>
+        <logstash-logback-encoder.version>8.1</logstash-logback-encoder.version>
+        <idempotency-starter.version>0.3.4</idempotency-starter.version>
+        <outbox-starter.version>0.1.3</outbox-starter.version>
         <mockito.agent.argLine>-javaagent:@{org.mockito:mockito-core:jar}</mockito.agent.argLine>
     </properties>
 


### PR DESCRIPTION
## Summary

Bumps the project version from 1.2.0-SNAPSHOT to 1.3.0-SNAPSHOT across all 
seven modules, and refreshes dependency versions per the issue: 
spring-boot-starter-parent (4.1.0→4.1.1), idempotency-starter (0.3.2→0.3.4), 
outbox-starter (0.1.0→0.1.3), jacoco (0.8.12→0.8.15), and 
logstash-logback-encoder (8.0→8.1). Also updates the starter version table 
in README.md to match.

## Related issues

Fixes #53

## Type of change

- [x] Refactoring / chore

## Affected modules

- [x] `outbox-events-contract`
- [x] `order-service`
- [x] `order-service-reactive`
- [x] `order-service-vt`
- [x] `notification-stub`
- [x] docs / CI / other

## Test plan

- [x] `mvn clean verify` — full build with integration tests (Testcontainers/PostgreSQL) passes locally

## Checklist

- [x] Code follows existing project conventions
- [x] Documentation updated (README starter version table)
- [x] No secrets or environment-specific credentials committed
- [x] No functional changes — version and dependency bumps only